### PR TITLE
Utilise PersistenceMarshaller instead of GlobalMarshaller

### DIFF
--- a/cachestores/src/main/java/org/infinispan/jmhbenchmarks/InfinispanHolder.java
+++ b/cachestores/src/main/java/org/infinispan/jmhbenchmarks/InfinispanHolder.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.RangeSet;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -40,7 +40,7 @@ public class InfinispanHolder {
 	@Param("100")
 	private int batchSize;
 
-	private StreamingMarshaller marshaller;
+	private Marshaller marshaller;
 	private EmbeddedCacheManager cacheManager;
 	private Cache cache;
 	private AdvancedLoadWriteStore store;
@@ -58,7 +58,7 @@ public class InfinispanHolder {
 				builder.build());
 		cache = cacheManager.getCache();
 
-		marshaller = TestingUtil.extractComponent(cache, StreamingMarshaller.class);
+		marshaller = TestingUtil.extractPersistenceMarshaller(cacheManager);
 		store = (AdvancedLoadWriteStore) TestingUtil.getFirstLoader(cache);
 		halfSegments = new RangeSet(cache.getCacheConfiguration().clustering().hash().numSegments() / 2);
 		keyPartitioner = TestingUtil.extractComponent(cache, KeyPartitioner.class);
@@ -80,7 +80,7 @@ public class InfinispanHolder {
 		}
 	}
 
-	public StreamingMarshaller getMarshaller() {
+	public Marshaller getMarshaller() {
 		return marshaller;
 	}
 

--- a/cachestores/src/main/java/org/infinispan/jmhbenchmarks/JMHBenchmarks.java
+++ b/cachestores/src/main/java/org/infinispan/jmhbenchmarks/JMHBenchmarks.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.distribution.ch.KeyPartitioner;
@@ -33,7 +33,7 @@ import io.reactivex.Flowable;
 		"-XX:LargePageSizeInBytes=2m"})
 @BenchmarkMode(Mode.Throughput)
 public class JMHBenchmarks {
-	private static MarshallableEntry newEntry(StreamingMarshaller marshaller, KeySequenceGenerator generator) {
+	private static MarshallableEntry newEntry(Marshaller marshaller, KeySequenceGenerator generator) {
 		InternalCacheEntry ice = TestInternalCacheEntryFactory.create(generator.getNextKey(), generator.getNextValue());
 		return MarshalledEntryUtil.create(ice, marshaller);
 	}
@@ -47,7 +47,7 @@ public class JMHBenchmarks {
 	public void testWriteBatch(InfinispanHolder holder, KeySequenceGenerator generator) {
 		int batchSize = holder.getBatchSize();
 		Set<MarshallableEntry> batch = new HashSet<>(batchSize);
-		StreamingMarshaller marshaller = holder.getMarshaller();
+		Marshaller marshaller = holder.getMarshaller();
 		for (int i = 0; i < holder.getBatchSize(); ++i) {
 			batch.add(newEntry(marshaller, generator));
 		}


### PR DESCRIPTION
@wburns I'm running locally to verify, but this could partly explain why performance was so poor in your benchmarks. In Infinispan 10.0, all marshalling is executed directly by the `PersistenceMarshaller`, whereas the benchmark is currently using the `GlobalMarshaller`. 