### PR TITLE
Adding Resp decoder based benchmark

### DIFF
--- a/resp-decoder/pom.xml
+++ b/resp-decoder/pom.xml
@@ -1,0 +1,183 @@
+<!--
+Copyright (c) 2014, Oracle America, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+ * Neither the name of Oracle nor the names of its contributors may be used
+   to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sample</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <name>JMH benchmark sample: Java</name>
+
+    <!--
+       This is the demo/sample template build script for building Java benchmarks with JMH.
+       Edit as needed.
+    -->
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>6.2.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-resp</artifactId>
+            <version>15.0.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!--
+            JMH version to use with this project.
+          -->
+        <jmh.version>1.36</jmh.version>
+
+        <!--
+            Java source/target to use for compilation.
+          -->
+        <javac.target>11</javac.target>
+
+        <!--
+            Name of the benchmark Uber-JAR to generate.
+          -->
+        <uberjar.name>decoder-benchmark</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/GetSetState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/GetSetState.java
@@ -1,0 +1,23 @@
+package org.infinispan.server.resp;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+
+@State(Scope.Benchmark)
+public class GetSetState extends NettyChannelState {
+   public ByteBuf GET_REQUEST;
+   public ByteBuf SET_REQUEST;
+
+   @Setup
+   public void initializeState() {
+      super.initializeState();
+
+      GET_REQUEST = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer("*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n", CharsetUtil.US_ASCII));
+      SET_REQUEST = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n", CharsetUtil.US_ASCII));
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2014, Oracle America, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Oracle nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.infinispan.server.resp;
+
+import java.util.Queue;
+
+import org.infinispan.server.resp.GetSetState;
+import org.infinispan.server.resp.PipelineState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.netty.buffer.ByteBuf;
+
+@Warmup(time = 5)
+@Fork(1)
+public class MyBenchmark {
+
+    @Benchmark
+    public ByteBuf testGetPerf(GetSetState state) {
+        state.channel.writeInbound(state.GET_REQUEST.duplicate());
+
+        // Should return immediately
+        ByteBuf buf = state.channel.readOutbound();
+        // $ + bytes length + \r\n + (bytes) + \r\n
+        int writtenAmount = buf.writerIndex() - buf.readerIndex();
+        if (writtenAmount != 1 + 1 + 2 + 2 + 2) {
+            throw new AssertionError("Set should have returned 5 bytes, but was " + writtenAmount);
+        }
+        buf.release();
+        return buf;
+    }
+
+    @Benchmark
+    public ByteBuf testSetPerf(GetSetState state) {
+        state.channel.writeInbound(state.SET_REQUEST.duplicate());
+
+        // Should return immediately
+        ByteBuf buf = state.channel.readOutbound();
+        // + + OK + \r\n
+        int writtenAmount = buf.writerIndex() - buf.readerIndex();
+        if (writtenAmount != 1 + 2 + 2) {
+            throw new AssertionError("Set should have returned 5 bytes, but was " + writtenAmount);
+        }
+        buf.release();
+        return buf;
+    }
+
+    @Benchmark
+    public void testGetPipelinePerf(PipelineState state) {
+        state.channel.writeInbound(state.GET_REQUEST.writerIndex(state.getWriteIndex).readerIndex(0));
+        state.channel.checkException();
+
+        // Should return immediately
+        Queue<Object> queue = state.channel.outboundMessages();
+        ByteBuf outbound;
+
+        int writtenAmount = 0;
+        while ((outbound = (ByteBuf) queue.poll()) != null) {
+            writtenAmount += outbound.writerIndex() - outbound.readerIndex();
+            outbound.release();
+        }
+        // $ + bytes length + \r\n + (bytes) + \r\n
+        if (writtenAmount != 8 * state.messageCount) {
+            throw new AssertionError("Set should have returned " + 8 * state.messageCount + " bytes, but was " + writtenAmount);
+        }
+    }
+
+    @Benchmark
+    public void testSetPipelinePerf(PipelineState state) {
+        state.channel.writeInbound(state.SET_REQUEST.writerIndex(state.setWriteIndex).readerIndex(0));
+        state.channel.checkException();
+
+        // Should return immediately
+        Queue<Object> queue = state.channel.outboundMessages();
+        ByteBuf outbound;
+
+        int writtenAmount = 0;
+        while ((outbound = (ByteBuf) queue.poll()) != null) {
+            writtenAmount += outbound.writerIndex() - outbound.readerIndex();
+            outbound.release();
+        }
+        if (writtenAmount != 5 * state.messageCount) {
+            throw new AssertionError("Set should have returned " + 5 * state.messageCount + " bytes, but was " + writtenAmount);
+        }
+    }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
@@ -1,0 +1,42 @@
+package org.infinispan.server.resp;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+@State(Scope.Benchmark)
+public class NettyChannelState {
+   public enum DECODER {
+      LETTUCE,
+      GENERATED
+   }
+
+   @Param
+   public GetSetState.DECODER decoderToUse;
+
+   public EmbeddedChannel channel;
+
+   @Setup
+   public void initializeState() {
+
+      channel = new EmbeddedChannel();
+      channel.config().setAllocator(PooledByteBufAllocator.DEFAULT);
+
+      OurRespHandler ourRespHandler = new OurRespHandler();
+
+      switch (decoderToUse) {
+         case LETTUCE:
+            channel.pipeline()
+                  .addLast(new RespLettuceHandler(ourRespHandler));
+            break;
+         case GENERATED:
+            channel.pipeline()
+                  .addLast(new RespDecoder(ourRespHandler));
+            break;
+      }
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/OurRespHandler.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/OurRespHandler.java
@@ -1,0 +1,53 @@
+package org.infinispan.server.resp;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.util.function.TriConsumer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.CharsetUtil;
+
+public class OurRespHandler extends RespRequestHandler {
+   private static final CompletableFuture<byte[]> GET_FUTURE = CompletableFuture.completedFuture(new byte[] { 0x1, 0x12});
+   public static ByteBuf OK = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer("+OK\r\n", CharsetUtil.US_ASCII));
+
+   // Returns a cached OK status that is retained for multiple uses
+   static ByteBuf statusOK() {
+      return OK.duplicate();
+   }
+
+   @Override
+   public CompletionStage<RespRequestHandler> handleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+      switch (type) {
+         case "GET":
+            return stageToReturn(GET_FUTURE, ctx, GET_TRICONSUMER);
+         case "SET":
+            return stageToReturn(CompletableFutures.completedNull(), ctx, SET_TRICONSUMER);
+      }
+      return super.handleRequest(ctx, type, arguments);
+   }
+
+   private static final TriConsumer<byte[], ChannelHandlerContext, Throwable> SET_TRICONSUMER = (ignore, innerCtx, t) -> {
+      if (t != null) {
+         throw new AssertionError(t);
+      } else {
+         innerCtx.writeAndFlush(statusOK(), innerCtx.voidPromise());
+      }
+   };
+
+   private static final TriConsumer<byte[], ChannelHandlerContext, Throwable> GET_TRICONSUMER = (innerValueBytes, innerCtx, t) -> {
+      if (t != null) {
+         throw new AssertionError(t);
+      } else if (innerValueBytes != null) {
+         ByteBuf buf = bytesToResult(innerValueBytes, innerCtx.alloc());
+         innerCtx.writeAndFlush(buf, innerCtx.voidPromise());
+      } else {
+         innerCtx.writeAndFlush(RespRequestHandler.stringToByteBuf("$-1\r\n", innerCtx.alloc()), innerCtx.voidPromise());
+      }
+   };
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/PipelineState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/PipelineState.java
@@ -1,0 +1,44 @@
+package org.infinispan.server.resp;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+
+public class PipelineState extends NettyChannelState {
+   @Param({"2", "25"})
+   public int messageCount;
+
+   public ByteBuf GET_REQUEST;
+
+   public ByteBuf SET_REQUEST;
+
+   public int getWriteIndex;
+   public int setWriteIndex;
+
+   @Setup
+   public void initializeState() {
+      super.initializeState();
+
+      CompositeByteBuf getBuffer = Unpooled.compositeBuffer(messageCount);
+      for (int i = 0; i < messageCount; ++i) {
+         getBuffer.addComponent(true, Unpooled.copiedBuffer("*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n", CharsetUtil.US_ASCII));
+      }
+
+      GET_REQUEST = Unpooled.unreleasableBuffer(getBuffer);
+
+      getWriteIndex = GET_REQUEST.writerIndex();
+
+      CompositeByteBuf setBuffer = Unpooled.compositeBuffer(messageCount);
+      for (int i = 0; i < messageCount; ++i) {
+         getBuffer.addComponent(true, Unpooled.copiedBuffer("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n", CharsetUtil.US_ASCII));
+      }
+
+      SET_REQUEST = Unpooled.unreleasableBuffer(setBuffer);
+
+      setWriteIndex = SET_REQUEST.writerIndex();
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/RespLettuceHandler.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/RespLettuceHandler.java
@@ -1,0 +1,221 @@
+package org.infinispan.server.resp;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.util.Util;
+import org.infinispan.server.resp.RespRequestHandler;
+import org.infinispan.server.resp.logging.Log;
+import org.infinispan.util.concurrent.CompletionStages;
+
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.output.CommandOutput;
+import io.lettuce.core.protocol.RedisStateMachine;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+public class RespLettuceHandler extends ByteToMessageDecoder {
+   private final static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
+
+   private final RedisStateMachine stateMachine = new RedisStateMachine(ByteBufAllocator.DEFAULT);
+   private RespRequestHandler requestHandler;
+   private final OurCommandOutput<byte[], byte[]> currentOutput = new OurCommandOutput<>(ByteArrayCodec.INSTANCE);
+   private boolean disabledRead = false;
+
+   public RespLettuceHandler(RespRequestHandler initialHandler) {
+      this.requestHandler = initialHandler;
+   }
+
+   @Override
+   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+      super.channelUnregistered(ctx);
+      stateMachine.close();
+      requestHandler.handleChannelDisconnect(ctx);
+   }
+
+   private static class OurCommandOutput<K, V> extends CommandOutput<K, V, List<Object>> {
+
+      /**
+       * Initialize a new instance that encodes and decodes keys and values using the supplied codec.
+       *
+       * @param codec Codec used to encode/decode keys and values, must not be {@code null}.
+       */
+      public OurCommandOutput(RedisCodec<K, V> codec) {
+         super(codec, Collections.emptyList());
+         stack = new ArrayDeque<>();
+      }
+
+      public void reset() {
+         stack.clear();
+         output.clear();
+         depth = 0;
+         type = null;
+      }
+
+      // Copied from PushOutput
+      private String type;
+
+      @Override
+      public void set(ByteBuffer bytes) {
+
+         if (type == null) {
+            bytes.mark();
+            // TODO: avoid DirectByteBuffer allocation
+            type = StringCodec.ASCII.decodeKey(bytes);
+            return;
+         }
+
+         if (!initialized) {
+            output = new ArrayList<>();
+         }
+
+         output.add(bytes == null ? null : codec.decodeValue(bytes));
+      }
+
+      @Override
+      public void setSingle(ByteBuffer bytes) {
+         if (type == null) {
+            set(bytes);
+         }
+         if (!initialized) {
+            output = new ArrayList<>();
+         }
+
+         output.add(bytes == null ? null : StringCodec.UTF8.decodeValue(bytes));
+      }
+
+      public String type() {
+         return type;
+      }
+
+      public List<Object> getContent() {
+
+         List<Object> copy = new ArrayList<>();
+
+         for (Object o : get()) {
+            if (o instanceof ByteBuffer) {
+               copy.add(((ByteBuffer) o).asReadOnlyBuffer());
+            } else {
+               copy.add(o);
+            }
+         }
+
+         return Collections.unmodifiableList(copy);
+      }
+
+      // Copied from NestedMultiOutput
+
+      private final Deque<List<Object>> stack;
+
+      private int depth;
+
+      private boolean initialized;
+
+      @Override
+      public void set(long integer) {
+
+         if (!initialized) {
+            output = new ArrayList<>();
+         }
+
+         output.add(integer);
+      }
+
+      @Override
+      public void set(double number) {
+
+         if (!initialized) {
+            output = new ArrayList<>();
+         }
+
+         output.add(number);
+      }
+
+      @Override
+      public void complete(int depth) {
+         if (depth > 0 && depth < this.depth) {
+            output = stack.pop();
+            this.depth--;
+         }
+      }
+
+      @Override
+      public void multi(int count) {
+
+         if (!initialized) {
+            output = new ArrayList<>(count);
+            initialized = true;
+         }
+
+         List<Object> a = new ArrayList<>(count);
+         output.add(a);
+         stack.push(output);
+         output = a;
+         this.depth++;
+      }
+   }
+
+   @Override
+   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+      // Don't read any of the ByteBuf if we disabled reads
+      if (disabledRead) {
+         return;
+      }
+      if (stateMachine.decode(in, currentOutput)) {
+         String type = currentOutput.type().toUpperCase();
+         // Read a complete command, use a new one for next round
+         List<byte[]> contentToUse = (List) currentOutput.getContent();
+         currentOutput.reset();
+         if (log.isTraceEnabled()) {
+            log.tracef("Received command: %s with arguments %s", type, Util.toStr(contentToUse));
+         }
+         CompletionStage<RespRequestHandler> stage = requestHandler.handleRequest(ctx, type, contentToUse);
+         if (CompletionStages.isCompletedSuccessfully(stage)) {
+            requestHandler = CompletionStages.join(stage);
+         } else {
+            log.tracef("Disabling auto read for channel %s until previous command is complete", ctx.channel());
+            // Disable reading any more from socket - until command is complete
+            ctx.channel().config().setAutoRead(false);
+            disabledRead = true;
+            stage.whenComplete((handler, t) -> {
+               assert ctx.channel().eventLoop().inEventLoop();
+               log.tracef("Re-enabling auto read for channel %s as previous command is complete", ctx.channel());
+               ctx.channel().config().setAutoRead(true);
+               disabledRead = false;
+               if (t != null) {
+                  exceptionCaught(ctx, t);
+               } else {
+                  // Instate the new handler if there was no exception
+                  requestHandler = handler;
+               }
+
+               // If there is any readable bytes left before we paused make sure to try to decode, just in case
+               // if a pending message was read before we disabled auto read
+               ByteBuf buf = internalBuffer();
+               if (buf.isReadable()) {
+                  log.tracef("Bytes available from previous read for channel %s, trying decode directly", ctx.channel());
+                  // callDecode will call us until the ByteBuf is no longer consumed
+                  callDecode(ctx, buf, List.of());
+               }
+            });
+         }
+      }
+   }
+
+   @Override
+   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+      log.unexpectedException(cause);
+      ctx.close();
+   }
+}


### PR DESCRIPTION
Perf ran on my local machine (throughput with ops/s)

Benchmark                        |(decoderToUse)  |(messageCount)   | Score 
--------------|:-----:|:-----------:|----:|
MyBenchmark.testSetPerf              | GENERATED             |N/A  |1718762.511 
MyBenchmark.testSetPerf                 |LETTUCE             |N/A  |1269882.526 
MyBenchmark.testGetPerf               |GENERATED            | N/A  |1368643.241
MyBenchmark.testGetPerf |                LETTUCE             |N/A  |1122292.229  
MyBenchmark.testGetPipelinePerf       |GENERATED      |         2  |658979.269
MyBenchmark.testGetPipelinePerf   |      LETTUCE    |           2  |577440.475  
MyBenchmark.testGetPipelinePerf      | GENERATED     |         25  |64042.208 
MyBenchmark.testGetPipelinePerf         |LETTUCE              |25      |53248.723 

Note that while pipeline scales almost linearly with the amount of requests. This will be enhanced with future updates to the RESP decoder so this will scale much better.

Also I will most likely remove the LETTUCE decoder as we will no longer want to use it and it will reduce runtime of tests.