### PR TITLE
Testing new way to parse String commands

### DIFF
--- a/protostream/pom.xml
+++ b/protostream/pom.xml
@@ -1,0 +1,184 @@
+<!--
+Copyright (c) 2014, Oracle America, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+ * Neither the name of Oracle nor the names of its contributors may be used
+   to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sample</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <name>JMH benchmark sample: Java</name>
+
+    <!--
+       This is the demo/sample template build script for building Java benchmarks with JMH.
+       Edit as needed.
+    -->
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+            <version>${protostream.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream-processor</artifactId>
+            <version>${protostream.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!--
+            JMH version to use with this project.
+          -->
+        <jmh.version>1.36</jmh.version>
+
+        <!--
+            Java source/target to use for compilation.
+          -->
+        <javac.target>11</javac.target>
+
+        <!--
+            Name of the benchmark Uber-JAR to generate.
+          -->
+        <uberjar.name>protostream-benchmark</uberjar.name>
+        <protostream.version>4.6.3-SNAPSHOT</protostream.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/protostream/src/main/java/org/infinispan/protostream/ProtostreamBenchmark.java
+++ b/protostream/src/main/java/org/infinispan/protostream/ProtostreamBenchmark.java
@@ -1,0 +1,81 @@
+package org.infinispan.protostream;
+
+import static org.infinispan.protostream.userclasses.BenchmarkSerializationContextInitializer.INSTANCE;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.infinispan.protostream.userclasses.Address;
+import org.infinispan.protostream.userclasses.IracEntryVersion;
+import org.infinispan.protostream.userclasses.IracMetadata;
+import org.infinispan.protostream.userclasses.TopologyIracVersion;
+import org.infinispan.protostream.userclasses.User;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 6, time = 10)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ProtostreamBenchmark {
+
+   private final SerializationContext ctx;
+   private final Address address;
+   private final User user;
+   private final IracMetadata metadata;
+
+   public ProtostreamBenchmark() {
+      ctx = ProtobufUtil.newSerializationContext();
+      INSTANCE.registerSchema(ctx);
+      INSTANCE.registerMarshallers(ctx);
+      address = new Address("That street", "1234-567", 1024, true);
+      Set<Integer> accounts = new HashSet<>();
+      IntStream.range(10, 20).forEach(accounts::add);
+      List<Address> addresses = new ArrayList<>(4);
+      addresses.add(new Address("This street", "1234-678", 256, false));
+      addresses.add(new Address("The other street", "1234-789", 1, true));
+      addresses.add(new Address("Yet another street", "1111-222", 56, true));
+      addresses.add(new Address("Out of street", "3333-111", 1, true));
+      user = new User(10, "John", "Doe", accounts, addresses, 18, User.Gender.MALE, null, Instant.now(), Instant.now().plusMillis(TimeUnit.DAYS.toMillis(30)));
+      Map<String, TopologyIracVersion> versions = new HashMap<>();
+      versions.put("site_1", TopologyIracVersion.newVersion(10));
+      versions.put("site_2", TopologyIracVersion.newVersion(15).increment(15));
+      IracEntryVersion version = new IracEntryVersion(versions);
+      metadata = new IracMetadata("site_1", version);
+   }
+
+
+   @Benchmark
+   public void testMarshallAddress(Blackhole blackhole) throws IOException {
+      blackhole.consume(ProtobufUtil.toWrappedByteArray(ctx, address));
+   }
+
+   @Benchmark
+   public void testMarshallUser(Blackhole blackhole) throws IOException {
+      blackhole.consume(ProtobufUtil.toWrappedByteArray(ctx, user));
+   }
+
+   @Benchmark
+   public void testMarshallIracMetadata(Blackhole blackhole) throws IOException {
+      blackhole.consume(ProtobufUtil.toWrappedByteArray(ctx, metadata));
+   }
+
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/Address.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/Address.java
@@ -1,0 +1,86 @@
+package org.infinispan.protostream.userclasses;
+
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+@ProtoTypeId(1)
+public class Address {
+
+   private String street;
+   private String postCode;
+   private int number;
+   private boolean isCommercial;
+
+   @ProtoFactory
+   public Address(String street, String postCode, int number, boolean commercial) {
+      this.street = street;
+      this.postCode = postCode;
+      this.number = number;
+      this.isCommercial = commercial;
+   }
+
+   @ProtoField(1)
+   public String getStreet() {
+      return street;
+   }
+
+   public void setStreet(String street) {
+      this.street = street;
+   }
+
+   @ProtoField(2)
+   public String getPostCode() {
+      return postCode;
+   }
+
+   public void setPostCode(String postCode) {
+      this.postCode = postCode;
+   }
+
+   @ProtoField(value = 3, defaultValue = "1")
+   public int getNumber() {
+      return number;
+   }
+
+   public void setNumber(int number) {
+      this.number = number;
+   }
+
+   @ProtoField(value = 4, defaultValue = "false")
+   public boolean isCommercial() {
+      return isCommercial;
+   }
+
+   public void setCommercial(boolean isCommercial) {
+      this.isCommercial = isCommercial;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Address address = (Address) o;
+      return number == address.number &&
+            isCommercial == address.isCommercial &&
+            Objects.equals(street, address.street) &&
+            Objects.equals(postCode, address.postCode);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(street, postCode, number, isCommercial);
+   }
+
+   @Override
+   public String toString() {
+      return "Address{" +
+            "street='" + street + '\'' +
+            ", postCode='" + postCode + '\'' +
+            ", number=" + number +
+            ", isCommercial=" + isCommercial +
+            '}';
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/BenchmarkSerializationContextInitializer.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/BenchmarkSerializationContextInitializer.java
@@ -1,0 +1,23 @@
+package org.infinispan.protostream.userclasses;
+
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+/**
+ * TODO! document this
+ *
+ * @author Pedro Ruivo
+ */
+@AutoProtoSchemaBuilder(includeClasses = {
+      Address.class,
+      User.class,
+      IracMetadata.class,
+      IracEntryVersion.class,
+      IracEntryVersion.MapEntry.class,
+      TopologyIracVersion.class
+})
+public interface BenchmarkSerializationContextInitializer extends SerializationContextInitializer {
+
+   SerializationContextInitializer INSTANCE = new org.infinispan.protostream.userclasses.BenchmarkSerializationContextInitializerImpl();
+
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/IracEntryVersion.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/IracEntryVersion.java
@@ -1,0 +1,60 @@
+package org.infinispan.protostream.userclasses;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+@ProtoTypeId(4)
+public class IracEntryVersion {
+
+   private final MapEntry[] vectorClock;
+
+   private IracEntryVersion(MapEntry[] vectorClock) {
+      this.vectorClock = vectorClock;
+   }
+
+   public IracEntryVersion(Map<String, TopologyIracVersion> vectorClock) {
+      this.vectorClock = new MapEntry[vectorClock.size()];
+      int i = 0;
+      for (Map.Entry<String, TopologyIracVersion> entry : vectorClock.entrySet()) {
+         this.vectorClock[i++] = new MapEntry(entry.getKey(), entry.getValue());
+      }
+   }
+
+   @ProtoFactory
+   static IracEntryVersion protoFactory(List<MapEntry> entries) {
+      MapEntry[] vc = entries.toArray(new MapEntry[entries.size()]);
+      Arrays.sort(vc);
+      return new IracEntryVersion(vc);
+   }
+
+   @ProtoField(number = 1, collectionImplementation = ArrayList.class)
+   List<MapEntry> entries() {
+      return Arrays.asList(vectorClock);
+   }
+
+   @ProtoTypeId(5)
+   public static class MapEntry {
+
+      final String site;
+
+      @ProtoField(2)
+      final TopologyIracVersion version;
+
+      @ProtoFactory
+      MapEntry(String site, TopologyIracVersion version) {
+         this.site = site;
+         this.version = version;
+      }
+
+      @ProtoField(1)
+      public String getSite() {
+         return site;
+      }
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/IracMetadata.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/IracMetadata.java
@@ -1,0 +1,65 @@
+package org.infinispan.protostream.userclasses;
+
+import java.util.Objects;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+/**
+ * The metadata stored for an entry needed for IRAC (async cross-site replication).
+ *
+ * @author Pedro Ruivo
+ * @since 11.0
+ */
+@ProtoTypeId(3)
+public class IracMetadata {
+
+   private final String site;
+   private final IracEntryVersion version;
+
+   @ProtoFactory
+   public IracMetadata(String site, IracEntryVersion version) {
+      this.site = Objects.requireNonNull(site);
+      this.version = Objects.requireNonNull(version);
+   }
+
+   @ProtoField(1)
+   public String getSite() {
+      return site;
+   }
+
+   @ProtoField(2)
+   public IracEntryVersion getVersion() {
+      return version;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      IracMetadata that = (IracMetadata) o;
+
+      return site.equals(that.site) && version.equals(that.version);
+   }
+
+   @Override
+   public int hashCode() {
+      int result = site.hashCode();
+      result = 31 * result + version.hashCode();
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      return "IracMetadata{" +
+            "site='" + site + '\'' +
+            ", version=" + version +
+            '}';
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/TopologyIracVersion.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/TopologyIracVersion.java
@@ -1,0 +1,95 @@
+package org.infinispan.protostream.userclasses;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+import org.infinispan.protostream.descriptors.Type;
+
+@ProtoTypeId(6)
+public class TopologyIracVersion implements Comparable<TopologyIracVersion> {
+
+   public static final TopologyIracVersion NO_VERSION = new TopologyIracVersion(0, 0);
+   private static final Pattern PARSE_PATTERN = Pattern.compile("\\((\\d+):(\\d+)\\)");
+
+   private final int topologyId;
+   private final long version;
+
+   private TopologyIracVersion(int topologyId, long version) {
+      this.topologyId = topologyId;
+      this.version = version;
+   }
+
+   @ProtoFactory
+   public static TopologyIracVersion create(int topologyId, long version) {
+      return topologyId == 0 && version == 0 ? NO_VERSION : new TopologyIracVersion(topologyId, version);
+   }
+
+   public static TopologyIracVersion newVersion(int currentTopologyId) {
+      return new TopologyIracVersion(currentTopologyId, 1);
+   }
+
+   public static TopologyIracVersion max(TopologyIracVersion v1, TopologyIracVersion v2) {
+      return v1.compareTo(v2) < 0 ? v2 : v1;
+   }
+
+   public static TopologyIracVersion fromString(String s) {
+      Matcher m = PARSE_PATTERN.matcher(s);
+      if (!m.find()) {
+         return null;
+      }
+      int topology = Integer.parseInt(m.group(1));
+      long version = Long.parseLong(m.group(2));
+      return new TopologyIracVersion(topology, version);
+   }
+
+   @ProtoField(number = 1, type = Type.UINT32, defaultValue = "0")
+   public int getTopologyId() {
+      return topologyId;
+   }
+
+   @ProtoField(number = 2, type = Type.UINT64, defaultValue = "0")
+   public long getVersion() {
+      return version;
+   }
+
+   public TopologyIracVersion increment(int currentTopologyId) {
+      return currentTopologyId > topologyId ?
+            TopologyIracVersion.newVersion(currentTopologyId) :
+            new TopologyIracVersion(topologyId, version + 1);
+   }
+
+   @Override
+   public int compareTo(TopologyIracVersion other) {
+      int topologyCompare = Integer.compare(topologyId, other.topologyId);
+      return topologyCompare == 0 ? Long.compare(version, other.version) : topologyCompare;
+   }
+
+   @Override
+   public String toString() {
+      return '(' + Integer.toString(topologyId) + ':' + version + ')';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+
+      TopologyIracVersion that = (TopologyIracVersion) o;
+      return this.topologyId == that.topologyId &&
+            this.version == that.version;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = topologyId;
+      result = 31 * result + (int) (version ^ (version >>> 32));
+      return result;
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/User.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/User.java
@@ -1,0 +1,177 @@
+package org.infinispan.protostream.userclasses;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.infinispan.protostream.annotations.ProtoEnumValue;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+@ProtoTypeId(2)
+public class User {
+
+   public enum Gender {
+      @ProtoEnumValue(1)
+      MALE,
+      @ProtoEnumValue(2)
+      FEMALE
+   }
+
+   private int id;
+   private String name;
+   private String surname;
+   private Set<Integer> accountIds;
+   private List<Address> addresses;
+   private Integer age;
+   private Gender gender;
+   private String notes;
+   private Instant creationDate;
+   private Instant passwordExpirationDate;
+
+   @ProtoFactory
+   public User(int id, String name, String surname, Set<Integer> accountIds, List<Address> addresses, Integer age, Gender gender, String notes, Instant creationDate, Instant passwordExpirationDate) {
+      this.id = id;
+      this.name = name;
+      this.surname = surname;
+      this.accountIds = accountIds;
+      this.addresses = addresses;
+      this.age = age;
+      this.gender = gender;
+      this.notes = notes;
+      this.creationDate = creationDate;
+      this.passwordExpirationDate = passwordExpirationDate;
+   }
+
+   @ProtoField(value = 1, required = true)
+   public int getId() {
+      return id;
+   }
+
+   public void setId(int id) {
+      this.id = id;
+   }
+
+   @ProtoField(value = 2, collectionImplementation = HashSet.class)
+   public Set<Integer> getAccountIds() {
+      return accountIds;
+   }
+
+   public void setAccountIds(Set<Integer> accountIds) {
+      this.accountIds = accountIds;
+   }
+
+   @ProtoField(3)
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   @ProtoField(4)
+   public String getSurname() {
+      return surname;
+   }
+
+   public void setSurname(String surname) {
+      this.surname = surname;
+   }
+
+   @ProtoField(value = 5, collectionImplementation = ArrayList.class)
+   public List<Address> getAddresses() {
+      return addresses;
+   }
+
+   public void setAddresses(List<Address> addresses) {
+      this.addresses = addresses;
+   }
+
+   @ProtoField(value = 6, defaultValue = "18")
+   public Integer getAge() {
+      return age;
+   }
+
+   public void setAge(Integer age) {
+      this.age = age;
+   }
+
+   @ProtoField(7)
+   public Gender getGender() {
+      return gender;
+   }
+
+   public void setGender(Gender gender) {
+      this.gender = gender;
+   }
+
+   @ProtoField(8)
+   public String getNotes() {
+      return notes;
+   }
+
+   public void setNotes(String notes) {
+      this.notes = notes;
+   }
+
+   @ProtoField(value = 9, defaultValue = "0")
+   public Instant getCreationDate() {
+      return creationDate;
+   }
+
+   public void setCreationDate(Instant creationDate) {
+      this.creationDate = creationDate;
+   }
+
+   @ProtoField(value = 10, defaultValue = "0")
+   public Instant getPasswordExpirationDate() {
+      return passwordExpirationDate;
+   }
+
+   public void setPasswordExpirationDate(Instant passwordExpirationDate) {
+      this.passwordExpirationDate = passwordExpirationDate;
+   }
+
+   @Override
+   public String toString() {
+      return "User{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            ", surname='" + surname + '\'' +
+            ", accountIds=" + accountIds +
+            ", addresses=" + addresses +
+            ", age=" + age +
+            ", gender=" + gender +
+            ", notes=" + notes +
+            ", creationDate='" + creationDate + '\'' +
+            ", passwordExpirationDate='" + passwordExpirationDate + '\'' +
+            '}';
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      User user = (User) o;
+      return id == user.id &&
+            Objects.equals(name, user.name) &&
+            Objects.equals(surname, user.surname) &&
+            Objects.equals(accountIds, user.accountIds) &&
+            Objects.equals(addresses, user.addresses) &&
+            Objects.equals(age, user.age) &&
+            gender == user.gender &&
+            Objects.equals(notes, user.notes) &&
+            Objects.equals(creationDate, user.creationDate) &&
+            Objects.equals(passwordExpirationDate, user.passwordExpirationDate);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(id, name, surname, accountIds, addresses, age, gender, notes, creationDate, passwordExpirationDate);
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/LongProcessorOverride.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/LongProcessorOverride.java
@@ -2,7 +2,7 @@ package org.infinispan.server.resp;
 
 import io.netty.buffer.ByteBuf;
 
-public class LongProcessorOverride extends Intrinsics.Resp2LongProcessor {
+public class LongProcessorOverride extends NewIntrinsics.Resp2LongProcessor {
    static LongProcessorOverride INSTANCE = new LongProcessorOverride();
 
    private LongProcessorOverride() {

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/LongProcessorOverride.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/LongProcessorOverride.java
@@ -1,0 +1,18 @@
+package org.infinispan.server.resp;
+
+import io.netty.buffer.ByteBuf;
+
+public class LongProcessorOverride extends Intrinsics.Resp2LongProcessor {
+   static LongProcessorOverride INSTANCE = new LongProcessorOverride();
+
+   private LongProcessorOverride() {
+      complete = true;
+      // Always 0 until later?
+      bytesRead = 0;
+   }
+   @Override
+   public long getValue(ByteBuf buffer) {
+      return buffer.readableBytes() - 4;
+   }
+
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
@@ -124,14 +124,14 @@ public class MyBenchmark {
     public int testSimpleStringNameParsing(NameState nameState) {
         ByteBuf buf = nameState.nextRequest().duplicate();
         buf.readerIndex(buf.readerIndex() + 2);
-        String name = Intrinsics.simpleString(buf);
+        String name = NewIntrinsics.simpleString(buf);
         return NameState.Names.handleString(name);
     }
 
     @Benchmark
     public int testStringNameParsing(NameState nameState) {
         ByteBuf buf = nameState.nextRequest().duplicate();
-        String name = Intrinsics.bulkString(buf, LongProcessorOverride.INSTANCE);
+        String name = NewIntrinsics.bulkString(buf, LongProcessorOverride.INSTANCE);
         return NameState.Names.handleString(name);
     }
 

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/MyBenchmark.java
@@ -34,8 +34,6 @@ package org.infinispan.server.resp;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.server.resp.GetSetState;
-import org.infinispan.server.resp.PipelineState;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -120,5 +118,27 @@ public class MyBenchmark {
         if (writtenAmount != 5 * state.messageCount) {
             throw new AssertionError("Set should have returned " + 5 * state.messageCount + " bytes, but was " + writtenAmount);
         }
+    }
+
+    @Benchmark
+    public int testSimpleStringNameParsing(NameState nameState) {
+        ByteBuf buf = nameState.nextRequest().duplicate();
+        buf.readerIndex(buf.readerIndex() + 2);
+        String name = Intrinsics.simpleString(buf);
+        return NameState.Names.handleString(name);
+    }
+
+    @Benchmark
+    public int testStringNameParsing(NameState nameState) {
+        ByteBuf buf = nameState.nextRequest().duplicate();
+        String name = Intrinsics.bulkString(buf, LongProcessorOverride.INSTANCE);
+        return NameState.Names.handleString(name);
+    }
+
+    @Benchmark
+    public int testNewNameParsing(NameState nameState) {
+        ByteBuf buf = nameState.nextRequest().duplicate();
+        buf.readerIndex(buf.readerIndex() + 2);
+        return NameState.Names.handleByteBuf(buf);
     }
 }

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NameState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NameState.java
@@ -1,0 +1,167 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+
+@State(Scope.Benchmark)
+public class NameState {
+
+   int offset = 0;
+   ByteBuf[] requests;
+
+   @Setup
+   public void initializeState() {
+      Names[] possible = Names.values();
+      requests = new ByteBuf[possible.length];
+      Random random = new Random(873821);
+      for (int i = 0; i < requests.length; ++i) {
+         Names argument = possible[random.nextInt(possible.length)];
+         String argumentString = argument.name();
+         requests[i] = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer("\r\n" + argumentString + "\r\n", CharsetUtil.US_ASCII));
+      }
+
+   }
+
+   ByteBuf nextRequest() {
+      if (offset >= requests.length) {
+         offset = 0;
+      }
+      return requests[offset++];
+   }
+
+   public enum Names {
+      GET(1),
+      SET(2),
+      MSET(3),
+      MGET(4),
+      INCR(5),
+      DECR(6),
+      DEL(7),
+      CONFIG(8),
+      PING(9),
+      PUBLISH(10),
+      SUBSCRIBE(11),
+      RESET(12),
+      READWRITE(13),
+      READONLY(14),
+      COMMAND(15),
+      ECHO(16),
+      HELLO(17),
+      AUTH(18),
+      QUIT(19);
+
+      private static final Names[][] indexedNames;
+
+      static {
+         indexedNames = new Names[26][];
+         // Just manual for now
+         indexedNames[0] = new Names[] { AUTH };
+         indexedNames[2] = new Names[] { CONFIG, COMMAND };
+         indexedNames[3] = new Names[] { DECR, DEL };
+         indexedNames[4] = new Names[] { ECHO };
+         indexedNames[6] = new Names[] { GET };
+         indexedNames[7] = new Names[] { HELLO };
+         indexedNames[8] = new Names[] { INCR };
+         indexedNames[12] = new Names[] { MGET, MSET };
+         indexedNames[15] = new Names[] { PING, PUBLISH };
+         indexedNames[16] = new Names[] { QUIT };
+         indexedNames[17] = new Names[] { RESET, READWRITE, READONLY };
+         indexedNames[18] = new Names[] { SET, SUBSCRIBE };
+      }
+
+      private final int value;
+      private final byte[] bytes;
+
+      Names(int value) {
+         this.bytes = name().getBytes(StandardCharsets.US_ASCII);
+         this.value = value;
+      }
+
+      public static int handleByteBuf(ByteBuf buf) {
+         int readOffset = buf.readerIndex();
+         byte b = buf.getByte(readOffset);
+         byte ignoreCase = b >= 97 ? (byte) (b - 97) : (byte) (b - 65);
+         if (ignoreCase < 0 || ignoreCase > 25) {
+            throw new IllegalArgumentException();
+         }
+         Names[] target = indexedNames[ignoreCase];
+         if (target == null) {
+            throw new IllegalArgumentException();
+         }
+         for (Names possible : target) {
+            byte[] possibleBytes = possible.bytes;
+            // We already read the first char so ensure readable bytes are the same with the /r/n
+            if (buf.readableBytes() == (possibleBytes.length + 2)) {
+               boolean matches = true;
+               for (int i = 1; i < possibleBytes.length; ++i) {
+                  byte upperByte = possibleBytes[i];
+                  byte targetByte = buf.getByte(readOffset + i);
+                  if (upperByte == targetByte || upperByte + 22 == targetByte) {
+                     continue;
+                  }
+                  matches = false;
+                  break;
+               }
+               if (matches) {
+                  buf.readerIndex(readOffset + possibleBytes.length + 2);
+                  return possible.value;
+               }
+            }
+         }
+         throw new IllegalArgumentException();
+      }
+
+      public static int handleString(String name) {
+         switch (name.toUpperCase()) {
+            case "GET":
+               return GET.value;
+            case "SET":
+               return SET.value;
+            case "MSET":
+               return MSET.value;
+            case "MGET":
+               return MGET.value;
+            case "INCR":
+               return INCR.value;
+            case "DECR":
+               return DECR.value;
+            case "DEL":
+               return DEL.value;
+            case "CONFIG":
+               return CONFIG.value;
+            case "PING":
+               return PING.value;
+            case "PUBLISH":
+               return PUBLISH.value;
+            case "SUBSCRIBE":
+               return SUBSCRIBE.value;
+            case "RESET":
+               return RESET.value;
+            case "READWRITE":
+               return READWRITE.value;
+            case "READONLY":
+               return READONLY.value;
+            case "COMMAND":
+               return COMMAND.value;
+            case "ECHO":
+               return ECHO.value;
+            case "HELLO":
+               return HELLO.value;
+            case "AUTH":
+               return AUTH.value;
+            case "QUIT":
+               return QUIT.value;
+            default:
+               throw new UnsupportedOperationException("command " + name + " not found!");
+         }
+      }
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
@@ -13,7 +13,8 @@ public class NettyChannelState {
    public EmbeddedChannel channel;
 
    public enum DECODER {
-      CURRENT
+      CURRENT,
+      NEW
    }
 
    @Param
@@ -29,6 +30,10 @@ public class NettyChannelState {
          case CURRENT:
             channel.pipeline()
                   .addLast(new RespDecoder(new OurRespHandler()));
+            break;
+         case NEW:
+            channel.pipeline()
+                  .addLast(new NewRespDecoder(new NewRespHandler()));
             break;
       }
 

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NewBaseRespDecoder.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NewBaseRespDecoder.java
@@ -1,0 +1,160 @@
+package org.infinispan.server.resp;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.server.resp.logging.Log;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.infinispan.util.logging.LogFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+public abstract class NewBaseRespDecoder extends ByteToMessageDecoder {
+   protected final static Log log = LogFactory.getLog(RespDecoder.class, Log.class);
+   protected final static int MINIMUM_BUFFER_SIZE;
+   protected final NewIntrinsics.Resp2LongProcessor longProcessor = new NewIntrinsics.Resp2LongProcessor();
+   protected NewRespRequestHandler requestHandler;
+
+   protected ByteBuf outboundBuffer;
+   // Variable to resume auto read when channel can be written to again. Some commands may resume themselves after
+   // flush and may not want to also resume on writability changes
+   protected boolean resumeAutoReadOnWritability;
+
+   static {
+      MINIMUM_BUFFER_SIZE = Integer.parseInt(System.getProperty("infinispan.resp.minimum-buffer-size", "4096"));
+   }
+
+   protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, int size) {
+      if (outboundBuffer != null) {
+         if (outboundBuffer.writableBytes() > size) {
+            return outboundBuffer;
+         }
+         log.tracef("Writing buffer %s as request is larger than remaining", outboundBuffer);
+         ctx.write(outboundBuffer, ctx.voidPromise());
+      }
+      int allocatedSize = Math.max(size, MINIMUM_BUFFER_SIZE);
+      outboundBuffer = ctx.alloc().buffer(allocatedSize, allocatedSize);
+      return outboundBuffer;
+   }
+
+   private void flushBufferIfNeeded(ChannelHandlerContext ctx, boolean runOnEventLoop) {
+      if (outboundBuffer != null) {
+         log.tracef("Writing and flushing buffer %s", outboundBuffer);
+         if (runOnEventLoop) {
+            ctx.channel().eventLoop().execute(() -> {
+               ctx.writeAndFlush(outboundBuffer, ctx.voidPromise());
+               outboundBuffer = null;
+            });
+         } else {
+            ctx.writeAndFlush(outboundBuffer, ctx.voidPromise());
+            outboundBuffer = null;
+         }
+      }
+   }
+
+   @Override
+   public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+      ctx.channel().attr(NewRespRequestHandler.BYTE_BUF_POOL_ATTRIBUTE_KEY)
+            .set(size -> allocateBuffer(ctx, size));
+      super.channelRegistered(ctx);
+   }
+
+   @Override
+   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+      super.channelUnregistered(ctx);
+      requestHandler.handleChannelDisconnect(ctx);
+   }
+
+   @Override
+   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      // We may disable auto read until a command completes or flush. This is useful because some operations may need
+      // do a flush and then resume auto read. If the flush caused writability change we don't want to resume twice
+      if (ctx.channel().config().isAutoRead()) {
+         flushBufferIfNeeded(ctx, false);
+      }
+      super.channelReadComplete(ctx);
+   }
+
+   @Override
+   public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+      if (resumeAutoReadOnWritability && ctx.channel().isWritable()) {
+         resumeAutoReadOnWritability = false;
+         // Schedule a read resume after we are done to prevent stack overflow
+         ctx.channel().eventLoop().execute(() -> attemptReadResume(ctx));
+      }
+      super.channelWritabilityChanged(ctx);
+   }
+
+   protected void attemptReadResume(ChannelHandlerContext ctx) {
+      log.tracef("Re-enabling auto read for channel %s as previous command is complete", ctx.channel());
+      ctx.channel().config().setAutoRead(true);
+      // If there is any readable bytes left before we paused make sure to try to decode, just in case
+      // if a pending message was read before we disabled auto read
+      ByteBuf buf = internalBuffer();
+      if (buf.isReadable()) {
+         log.tracef("Bytes available from previous read for channel %s, trying decode directly", ctx.channel());
+         // callDecode will call us until the ByteBuf is no longer consumed
+         callDecode(ctx, buf, List.of());
+         // It is possible the decode above filled our outbound buffer again, so we can only flush if auto read is still enabled
+         if (ctx.channel().config().isAutoRead()) {
+            flushBufferIfNeeded(ctx, false);
+         }
+      }
+   }
+
+   /**
+    * Handles the actual command request. This entails passing the command to the request handler and if
+    * the request is completed the decoder may parse more commands.
+    *
+    * @param ctx channel context in use for this command
+    * @param command the actual command
+    * @param arguments the arguments provided to the command. The list should not be retained as it is reused
+    * @return boolean whether the decoder can read more bytes or must wait
+    */
+   protected boolean handleCommandAndArguments(ChannelHandlerContext ctx, RespCommand command, List<byte[]> arguments) {
+      if (log.isTraceEnabled()) {
+         log.tracef("Received command: %s with arguments %s for %s", command, Util.toStr(arguments), ctx.channel());
+      }
+
+      CompletionStage<NewRespRequestHandler> stage = requestHandler.handleRequest(ctx, command, arguments);
+      if (CompletionStages.isCompletedSuccessfully(stage)) {
+         requestHandler = CompletionStages.join(stage);
+         if (outboundBuffer != null && outboundBuffer.readableBytes() > ctx.channel().bytesBeforeUnwritable()) {
+            log.tracef("Buffer will cause channel %s to be unwriteable - forcing flush", ctx.channel());
+            // Note the flush is done later after this task completes, since we don't want to resume reading yet
+            flushBufferIfNeeded(ctx, true);
+            ctx.channel().config().setAutoRead(false);
+            resumeAutoReadOnWritability = true;
+            return false;
+         }
+         return true;
+      }
+      log.tracef("Disabling auto read for channel %s until previous command is complete", ctx.channel());
+      // Disable reading any more from socket - until command is complete
+      ctx.channel().config().setAutoRead(false);
+      stage.whenComplete((handler, t) -> {
+         assert ctx.channel().eventLoop().inEventLoop();
+         if (t != null) {
+            exceptionCaught(ctx, t);
+            return;
+         }
+         // Instate the new handler if there was no exception
+         requestHandler = handler;
+         flushBufferIfNeeded(ctx, false);
+         // Schedule a read resume after we are done to prevent stack overflow
+         ctx.channel().eventLoop().execute(() -> attemptReadResume(ctx));
+      });
+      return false;
+   }
+
+   @Override
+   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+      log.unexpectedException(cause);
+      RespRequestHandler.stringToByteBuf("-ERR Server Error Encountered: " + cause.getMessage() + "\\r\\n", requestHandler.allocatorToUse);
+      flushBufferIfNeeded(ctx, false);
+      ctx.close();
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NewIntrinsics.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NewIntrinsics.java
@@ -1,0 +1,179 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ByteProcessor;
+
+public class NewIntrinsics {
+   private static final int TERMINATOR_LENGTH = 2;
+
+   public static byte singleByte(ByteBuf buffer) {
+      if (buffer.isReadable()) {
+         return buffer.readByte();
+      } else return 0;
+   }
+
+   public static String simpleString(ByteBuf buf) {
+      // Find the end LF (would be nice to do this without iterating twice)
+      int offset = buf.forEachByte(ByteProcessor.FIND_LF);
+      if (offset <= 0) {
+         return null;
+      }
+      if (buf.getByte(offset - 1) != '\r') {
+         throw new IllegalStateException("No matching \r character found before \n");
+      }
+      String simpleString = buf.toString(buf.readerIndex(), offset - 1 - buf.readerIndex(), StandardCharsets.US_ASCII);
+      // toString doesn't move the reader index forward
+      buf.readerIndex(offset + 1);
+      return simpleString;
+   }
+
+   public static RespCommand simpleCommand(ByteBuf buf) {
+      // Find the end LF (would be nice to do this without iterating twice)
+      int offset = buf.forEachByte(ByteProcessor.FIND_LF);
+      if (offset <= 0) {
+         return null;
+      }
+      if (buf.getByte(offset - 1) != '\r') {
+         throw new IllegalStateException("No matching \r character found before \n");
+      }
+      return RespCommand.fromByteBuf(buf, offset - 1 - buf.readerIndex());
+   }
+
+   public static long readNumber(ByteBuf buf, Resp2LongProcessor longProcessor) {
+      long value = longProcessor.getValue(buf);
+      // The longProcessor can technically read up to only /r, we need to ensure there is /r and /n
+      if (longProcessor.complete && buf.readableBytes() >= longProcessor.bytesRead + TERMINATOR_LENGTH) {
+         buf.skipBytes(longProcessor.bytesRead + TERMINATOR_LENGTH);
+      }
+      return value;
+   }
+
+   public static byte[] readTerminatedBytes(ByteBuf buf) {
+      // Find the end LF (would be nice to do this without iterating twice)
+      int offset = buf.forEachByte(ByteProcessor.FIND_LF);
+      if (offset <= 0) {
+         return null;
+      }
+      if (buf.getByte(offset - 1) != '\r') {
+         throw new IllegalStateException("No matching \r character found before \n");
+      }
+      byte[] data = new byte[offset - 1 - buf.readerIndex()];
+      buf.readBytes(data);
+      buf.skipBytes(TERMINATOR_LENGTH);
+      return data;
+   }
+
+   /**
+    * This method is only used for numerics that when parsed must be 0 or positive
+    * If a valid number is returned, then the ByteBuf will have its read index moved to the next element
+    */
+   private static int readSizeAndCheckRemainder(ByteBuf buf, Resp2LongProcessor longProcessor) {
+      buf.markReaderIndex();
+      int pos = buf.readerIndex();
+      long longSize = readNumber(buf, longProcessor);
+      if (longSize > Integer.MAX_VALUE) {
+         throw new IllegalArgumentException("Bytes cannot be longer than " + Integer.MAX_VALUE);
+      }
+      // If we didn't read any bytes then the number wasn't parsed properly
+      if (pos == buf.readerIndex()) {
+         return -1;
+      }
+      int size = (int) longSize;
+      if (size < 0) {
+         throw new IllegalArgumentException("Number cannot be negative");
+      }
+      if (buf.readableBytes() < size + TERMINATOR_LENGTH) {
+         buf.resetReaderIndex();
+         return -1;
+      }
+      return size;
+   }
+
+   public static String bulkString(ByteBuf buf, Resp2LongProcessor longProcessor) {
+      int size = readSizeAndCheckRemainder(buf, longProcessor);
+      if (size == -1) {
+         return null;
+      }
+      String stringValue = buf.toString(buf.readerIndex(), size, StandardCharsets.US_ASCII);
+      buf.skipBytes(size + TERMINATOR_LENGTH);
+      return stringValue;
+   }
+
+   public static RespCommand bulkCommand(ByteBuf buf, Resp2LongProcessor longProcessor) {
+      int size = readSizeAndCheckRemainder(buf, longProcessor);
+      if (size == -1) {
+         return null;
+      }
+      return RespCommand.fromByteBuf(buf, size);
+   }
+
+   public static byte[] bulkArray(ByteBuf buf, Resp2LongProcessor longProcessor) {
+      int size = readSizeAndCheckRemainder(buf, longProcessor);
+      if (size == -1) {
+         return null;
+      }
+      byte[] array = new byte[size];
+      buf.readBytes(array);
+      buf.skipBytes(TERMINATOR_LENGTH);
+      return array;
+   }
+
+   static class Resp2LongProcessor implements ByteProcessor {
+      long result;
+      int bytesRead;
+      boolean complete;
+      boolean negative;
+      boolean first;
+
+      public long getValue(ByteBuf buffer) {
+
+         this.result = 0;
+         this.bytesRead = 0;
+         this.complete = false;
+         this.first = true;
+
+         // We didn't have enough to read the number
+         if (buffer.forEachByte(this) == -1) {
+            complete = false;
+            return -1;
+         }
+         complete = true;
+
+         if (!this.negative) {
+            this.result = -this.result;
+         }
+
+         return this.result;
+      }
+
+      @Override
+      public boolean process(byte value) {
+
+         if (value == '\r') {
+            return false;
+         }
+
+         bytesRead++;
+
+         if (first) {
+            first = false;
+
+            if (value == '-') {
+               negative = true;
+            } else {
+               negative = false;
+               int digit = value - '0';
+               result = result * 10 - digit;
+            }
+            return true;
+         }
+
+         int digit = value - '0';
+         result = result * 10 - digit;
+
+         return true;
+      }
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespDecoder.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespDecoder.java
@@ -1,0 +1,247 @@
+package org.infinispan.server.resp;
+import java.util.List;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+
+import java.lang.UnsupportedOperationException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class NewRespDecoder extends NewBaseRespDecoder {
+   private int state;
+   private int requestBytes;
+
+   private RespCommand resp3x_bulkCommand;
+   private byte[] resp3x_readTerminatedBytes;
+   private int resp3x_readSizeAndCheckRemainder;
+   private long resp3x_readNumber;
+   private byte[] resp3x_bulkArray;
+   private List< byte[]> resp3x_arguments;
+   private String resp3x_simpleString;
+   private RespCommand resp3x_simpleCommand;
+   private RespCommand resp3x_command;
+   private byte[] resp3x_array;
+   private String resp3x_bulkString;
+   private byte resp3x_singleByte;
+
+   private final List < byte[] > reusedList = new ArrayList < >(16);
+   public NewRespDecoder(NewRespRequestHandler initialHandler) {
+      this.requestHandler = initialHandler;
+   }
+
+   @Override
+   public void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> out) throws Exception {
+      int pos = buf.readerIndex();
+      try {
+         if (! ctx.channel().config().isAutoRead()) {
+            log.tracef("Auto read was disabled, not reading next bytes");
+            return;
+         } else {
+            log.tracef("Auto read was enabled, reading next bytes");
+         }
+         while (switch0(ctx, buf));
+      } catch (Throwable t) {
+         throw t;
+      } finally {
+         requestBytes += buf.readerIndex() - pos;
+      }
+   }
+
+   private boolean switch0(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
+      byte b;
+      int pos;
+      switch (state) {
+         case 0:
+            //
+            reset();
+            state = 1;
+            // fallthrough
+         case 1:
+            //
+            pos = buf.readerIndex();
+            resp3x_singleByte = NewIntrinsics.singleByte(buf);
+            if (buf.readerIndex() == pos) return false;
+            state = 2;
+            // fallthrough
+         case 2:
+            // resp3x.request
+            if (resp3x_singleByte != org.infinispan.server.resp.RespConstants.ARRAY) throw new UnsupportedOperationException("Only array types are supported, received: " + resp3x_singleByte);
+            reusedList.clear();
+
+            state = 3;
+            // fallthrough
+         case 3:
+            // resp3x.request
+            pos = buf.readerIndex();
+            resp3x_readNumber = NewIntrinsics.readNumber(buf, longProcessor);
+            if (buf.readerIndex() == pos) return false;
+            state = 5;
+            return true;
+         case 4:
+            // resp3x.request
+            pos = buf.readerIndex();
+            resp3x_singleByte = NewIntrinsics.singleByte(buf);
+            if (buf.readerIndex() == pos) return false;
+            state = 6;
+            return true;
+         case 5:
+            // resp3x.request/resp3x.number
+            resp3x_readNumber -= 1;
+
+            state = 4;
+            return true;
+         case 6:
+            // resp3x.request
+            switch (resp3x_singleByte) {
+               case org.infinispan.server.resp.RespConstants.BULK_STRING:
+                  state = 8;
+                  return true;
+               case org.infinispan.server.resp.RespConstants.SIMPLE_STRING:
+                  state = 9;
+                  return true;
+               default:
+                  throw new UnsupportedOperationException("Type not supported: " + resp3x_singleByte);
+
+            }
+         case 7:
+            // resp3x.request
+            if (resp3x_readNumber > 16) {
+               state = 11;
+               return true;
+            }
+            if (resp3x_readNumber >= 1) {
+               state = 12;
+               return true;
+            }
+            resp3x_arguments = Collections.emptyList();
+            ;
+            state = 10;
+            return true;
+         case 8:
+            // resp3x.request/resp3x.command
+            pos = buf.readerIndex();
+            resp3x_bulkCommand = NewIntrinsics.bulkCommand(buf, longProcessor);
+            if (buf.readerIndex() == pos) return false;
+            resp3x_command = resp3x_bulkCommand;
+            state = 7;
+            return true;
+         case 9:
+            // resp3x.request/resp3x.command
+            pos = buf.readerIndex();
+            resp3x_simpleCommand = NewIntrinsics.simpleCommand(buf);
+            if (buf.readerIndex() == pos) return false;
+            resp3x_command = resp3x_simpleCommand;
+            state = 7;
+            return true;
+         case 10:
+            // resp3x.request
+            if (resp3x_readNumber == 0) {
+               state = 13;
+               return true;
+            }
+            resp3x_readNumber--;
+            state = 14;
+            return true;
+         case 11:
+            // resp3x.request/resp3x.arguments
+            resp3x_arguments = new ArrayList < >((int) resp3x_readNumber);
+            ;
+            state = 10;
+            return true;
+         case 12:
+            // resp3x.request/resp3x.arguments
+            resp3x_arguments = reusedList;
+            ;
+            state = 10;
+            return true;
+         case 13:
+            // resp3x.request
+            if (! handleCommandAndArguments(ctx, resp3x_command, resp3x_arguments)) {
+               state = 0;
+               return false;
+            }
+            ;
+
+            state = 0;
+            return true;
+         case 14:
+            // resp3x.request
+            pos = buf.readerIndex();
+            resp3x_singleByte = NewIntrinsics.singleByte(buf);
+            if (buf.readerIndex() == pos) return false;
+            state = 15;
+            // fallthrough
+         case 15:
+            // resp3x.request
+            switch (resp3x_singleByte) {
+               case org.infinispan.server.resp.RespConstants.BULK_STRING:
+                  state = 17;
+                  return true;
+               case org.infinispan.server.resp.RespConstants.SIMPLE_STRING:
+                  state = 18;
+                  return true;
+               case org.infinispan.server.resp.RespConstants.NUMERIC:
+                  state = 19;
+                  return true;
+               default:
+                  throw new UnsupportedOperationException("Type not supported: " + resp3x_singleByte);
+
+            }
+         case 16:
+            // resp3x.request
+            resp3x_arguments.add(resp3x_array);
+
+            state = 10;
+            return true;
+         case 17:
+            // resp3x.request/resp3x.array
+            pos = buf.readerIndex();
+            resp3x_bulkArray = NewIntrinsics.bulkArray(buf, longProcessor);
+            if (buf.readerIndex() == pos) return false;
+            resp3x_array = resp3x_bulkArray;
+            state = 16;
+            return true;
+         case 18:
+            // resp3x.request/resp3x.array
+            pos = buf.readerIndex();
+            resp3x_readTerminatedBytes = NewIntrinsics.readTerminatedBytes(buf);
+            if (buf.readerIndex() == pos) return false;
+            resp3x_array = resp3x_readTerminatedBytes;
+            state = 16;
+            return true;
+         case 19:
+            // resp3x.request/resp3x.array
+            pos = buf.readerIndex();
+            resp3x_readTerminatedBytes = NewIntrinsics.readTerminatedBytes(buf);
+            if (buf.readerIndex() == pos) return false;
+            resp3x_array = resp3x_readTerminatedBytes;
+            state = 16;
+            return true;
+      }
+      return true;
+   }
+
+   private void deadEnd() {
+      throw new IllegalArgumentException();
+   }
+
+   private void reset() {
+      requestBytes = 0;
+      resp3x_bulkCommand = null;
+      resp3x_readTerminatedBytes = null;
+      resp3x_readSizeAndCheckRemainder = 0;
+      resp3x_readNumber = 0;
+      resp3x_bulkArray = null;
+      resp3x_arguments = null;
+      resp3x_simpleString = null;
+      resp3x_simpleCommand = null;
+      resp3x_command = null;
+      resp3x_array = null;
+      resp3x_bulkString = null;
+      resp3x_singleByte = 0;
+   }
+
+   public int requestBytes() {
+      return requestBytes;
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespHandler.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespHandler.java
@@ -10,16 +10,16 @@ import org.infinispan.commons.util.concurrent.CompletableFutures;
 
 import io.netty.channel.ChannelHandlerContext;
 
-public class OurRespHandler extends RespRequestHandler {
+public class NewRespHandler extends NewRespRequestHandler {
    private static final CompletableFuture<byte[]> GET_FUTURE = CompletableFuture.completedFuture(new byte[] { 0x1, 0x12});
    public static byte[] OK = "+OK\r\n".getBytes(StandardCharsets.US_ASCII);
 
    @Override
-   public CompletionStage<RespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, String type, List<byte[]> arguments) {
+   public CompletionStage<NewRespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
       switch (type) {
-         case "GET":
+         case GET:
             return stageToReturn(GET_FUTURE, ctx, GET_TRICONSUMER);
-         case "SET":
+         case SET:
             return stageToReturn(CompletableFutures.completedNull(), ctx, OK_BICONSUMER);
       }
       return super.handleRequest(ctx, type, arguments);

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespRequestHandler.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NewRespRequestHandler.java
@@ -1,0 +1,270 @@
+package org.infinispan.server.resp;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.util.concurrent.CompletionStages;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeKey;
+
+public abstract class NewRespRequestHandler {
+   protected final CompletionStage<NewRespRequestHandler> myStage = CompletableFuture.completedFuture(this);
+
+   public static final AttributeKey<ByteBufPool> BYTE_BUF_POOL_ATTRIBUTE_KEY = AttributeKey.newInstance("buffer-pool");
+
+   ByteBufPool allocatorToUse;
+
+   protected void initializeIfNecessary(ChannelHandlerContext ctx) {
+      if (allocatorToUse == null) {
+         if (!ctx.channel().hasAttr(BYTE_BUF_POOL_ATTRIBUTE_KEY)) {
+            throw new IllegalStateException("BufferPool was not initialized in the context " + ctx);
+         }
+         allocatorToUse = ctx.channel().attr(BYTE_BUF_POOL_ATTRIBUTE_KEY).get();
+      }
+   }
+
+   public final CompletionStage<NewRespRequestHandler> handleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
+      initializeIfNecessary(ctx);
+      if (type == null) {
+         stringToByteBuf("-ERR unknown command\r\n", allocatorToUse);
+         return myStage;
+      }
+      return actualHandleRequest(ctx, type, arguments);
+   }
+
+   /**
+    * Handles the RESP request returning a stage that when complete notifies the command has completed as well as
+    * providing the request handler for subsequent commands.
+    * <p>
+    * Implementations should never use the ByteBufAllocator in the context.
+    * Instead, they should use {@link #allocatorToUse} to retrieve a ByteBuffer.
+    * This ByteBuffer should only have bytes written to it adding up to the size requested.
+    * The ByteBuffer itself should never be written to the context or channel and flush should also never be invoked.
+    * Failure to do so may cause mis-ordering or responses as requests support pipelining and a ByteBuf may not be
+    * send down stream until later in the pipeline.
+    *
+    * @param ctx Netty context pipeline for this request
+    * @param type The command type
+    * @param arguments The remaining arguments to the command
+    * @return stage that when complete returns the new handler to instate. This stage <b>must</b> be completed on the event loop
+    */
+   protected CompletionStage<NewRespRequestHandler> actualHandleRequest(ChannelHandlerContext ctx, RespCommand type, List<byte[]> arguments) {
+      if (type == RespCommand.QUIT) {
+         ctx.close();
+         return myStage;
+      }
+      stringToByteBuf("-ERR unknown command\r\n", allocatorToUse);
+      return myStage;
+   }
+
+   public void handleChannelDisconnect(ChannelHandlerContext ctx) {
+      // Do nothing by default
+   }
+
+   protected <E> CompletionStage<NewRespRequestHandler> stageToReturn(CompletionStage<E> stage, ChannelHandlerContext ctx,
+         BiConsumer<? super E, ByteBufPool> biConsumer) {
+      return stageToReturn(stage, ctx, Objects.requireNonNull(biConsumer), null);
+   }
+
+   protected <E> CompletionStage<NewRespRequestHandler> stageToReturn(CompletionStage<E> stage, ChannelHandlerContext ctx,
+         Function<E, NewRespRequestHandler> handlerWhenComplete) {
+      return stageToReturn(stage, ctx, null, Objects.requireNonNull(handlerWhenComplete));
+   }
+
+   /**
+    * Handles ensuring that a stage TriConsumer is only invoked on the event loop. The TriConsumer can then do things
+    * such as writing to the underlying channel or update variables in a thread safe manner without additional
+    * synchronization or volatile variables.
+    * <p>
+    * If the TriConsumer provided is null the provided stage <b>must</b> be completed only on the event loop of the
+    * provided ctx.
+    * This can be done via the Async methods on {@link CompletionStage} such as {@link CompletionStage#thenApplyAsync(Function, Executor)};
+    * <p>
+    * If the returned stage was completed exceptionally, any exception is ignored, assumed to be handled in the
+    * <b>biConsumer</b> or further up the stage.
+    * The <b>handlerWhenComplete</b> is not invoked if the stage was completed exceptionally as well.
+    * If the <b>triConsumer</b> or <b>handlerWhenComplete</b> throw an exception when invoked the returned stage will
+    * complete with that exception.
+    * <p>
+    * This method can only be invoked on the event loop for the provided ctx.
+    *
+    * @param <E> The stage return value
+    * @param stage The stage that will complete. Note that if biConsumer is null this stage may only be completed on the event loop
+    * @param ctx The context used for this request, normally the event loop is the thing used
+    * @param biConsumer The consumer to be ran on
+    * @param handlerWhenComplete A function to map the result to which handler will be used for future requests. Only ever invoked on the event loop. May be null, if so the current handler is returned
+    * @return A stage that is only ever completed on the event loop that provides the new handler to use
+    */
+   private <E> CompletionStage<NewRespRequestHandler> stageToReturn(CompletionStage<E> stage, ChannelHandlerContext ctx,
+         BiConsumer<? super E, ByteBufPool> biConsumer, Function<E, NewRespRequestHandler> handlerWhenComplete) {
+      assert ctx.channel().eventLoop().inEventLoop();
+      // Only one or the other can be null
+      assert (biConsumer != null && handlerWhenComplete == null) || (biConsumer == null && handlerWhenComplete != null) :
+            "triConsumer was: " + biConsumer + " and handlerWhenComplete was: " + handlerWhenComplete;
+      if (CompletionStages.isCompletedSuccessfully(stage)) {
+         E result = CompletionStages.join(stage);
+         try {
+            if (handlerWhenComplete != null) {
+               return CompletableFuture.completedFuture(handlerWhenComplete.apply(result));
+            }
+            biConsumer.accept(result, allocatorToUse);
+         } catch (Throwable t) {
+            return CompletableFutures.completedExceptionFuture(t);
+         }
+         return myStage;
+      }
+      if (biConsumer != null) {
+         // Note that this method is only ever invoked in the event loop, so this whenCompleteAsync can never complete
+         // until this request completes, meaning the thenApply will always be invoked in the event loop as well
+         return CompletionStages.handleAndComposeAsync(stage, (e, t) -> {
+            if (t != null) {
+               Resp3Handler.handleThrowable(allocatorToUse, t);
+            } else {
+               try {
+                  biConsumer.accept(e, allocatorToUse);
+               } catch (Throwable innerT) {
+                  return CompletableFutures.completedExceptionFuture(innerT);
+               }
+            }
+            return myStage;
+         }, ctx.channel().eventLoop());
+      }
+      return stage.handle((value, t) -> {
+         if (t != null) {
+            // If exception, never use handler
+            return this;
+         }
+         return handlerWhenComplete.apply(value);
+      });
+   }
+
+   protected static ByteBuf stringToByteBufWithExtra(CharSequence string, ByteBufPool alloc, int extraBytes) {
+      boolean release = true;
+      int stringBytes = ByteBufUtil.utf8Bytes(string);
+      int allocatedSize = stringBytes + extraBytes;
+      ByteBuf buffer = alloc.apply(allocatedSize);
+
+      try {
+         int beforeWriteIndex = buffer.writerIndex();
+         ByteBufUtil.reserveAndWriteUtf8(buffer, string, allocatedSize);
+         assert buffer.capacity() - buffer.writerIndex() > extraBytes;
+         assert buffer.writerIndex() - beforeWriteIndex == stringBytes;
+         release = false;
+      } finally {
+         if (release) {
+            buffer.release();
+         }
+      }
+
+      return buffer;
+   }
+
+   protected static ByteBuf stringToByteBuf(CharSequence string, ByteBufPool alloc) {
+      return stringToByteBufWithExtra(string, alloc, 0);
+   }
+
+   protected static ByteBuf bytesToResult(byte[] result, ByteBufPool alloc) {
+      int length = result.length;
+      int stringLength = stringSize(length);
+
+      // Need 5 extra for $ and 2 sets of /r/n
+      int exactSize = stringLength + length + 5;
+      ByteBuf buffer = alloc.acquire(exactSize);
+      buffer.writeByte('$');
+      // This method is anywhere from 10-100% faster than ByteBufUtil.writeAscii and avoids allocations
+      setIntChars(length, stringLength, buffer);
+      buffer.writeByte('\r').writeByte('\n');
+      buffer.writeBytes(result);
+      buffer.writeByte('\r').writeByte('\n');
+
+      return buffer;
+   }
+
+   protected static int stringSize(int x) {
+      int d = 1;
+      if (x >= 0) {
+         d = 0;
+         x = -x;
+      }
+      int p = -10;
+      for (int i = 1; i < 10; i++) {
+         if (x > p)
+            return i + d;
+         p = 10 * p;
+      }
+      return 10 + d;
+   }
+
+   // This code is a modified version of Integer.toString to write the underlying bytes directly to the ByteBuffer
+   // instead of creating a String around a byte[]
+   protected static int setIntChars(int i, int index, ByteBuf buf) {
+      int writeIndex = buf.writerIndex();
+      int q, r;
+      int charPos = index;
+
+      boolean negative = i < 0;
+      if (!negative) {
+         i = -i;
+      }
+
+      // Generate two digits per iteration
+      while (i <= -100) {
+         q = i / 100;
+         r = (q * 100) - i;
+         i = q;
+         buf.setByte(writeIndex + --charPos, DigitOnes[r]);
+         buf.setByte(writeIndex + --charPos, DigitTens[r]);
+      }
+
+      // We know there are at most two digits left at this point.
+      q = i / 10;
+      r = (q * 10) - i;
+      buf.setByte(writeIndex + --charPos, (byte) ('0' + r));
+
+      // Whatever left is the remaining digit.
+      if (q < 0) {
+         buf.setByte(writeIndex + --charPos, (byte) ('0' - q));
+      }
+
+      if (negative) {
+         buf.setByte(writeIndex + --charPos, (byte) '-');
+      }
+      buf.writerIndex(writeIndex + index);
+      return charPos;
+   }
+
+   static final byte[] DigitTens = {
+         '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+         '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
+         '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
+         '3', '3', '3', '3', '3', '3', '3', '3', '3', '3',
+         '4', '4', '4', '4', '4', '4', '4', '4', '4', '4',
+         '5', '5', '5', '5', '5', '5', '5', '5', '5', '5',
+         '6', '6', '6', '6', '6', '6', '6', '6', '6', '6',
+         '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
+         '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
+         '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
+   };
+
+   static final byte[] DigitOnes = {
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+   };
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/RespCommand.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/RespCommand.java
@@ -1,0 +1,98 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.ByteBuf;
+
+public enum RespCommand {
+   GET,
+   SET,
+   INCR,
+   DECR,
+   DEL,
+   MSET,
+   MGET,
+   PUBLISH,
+   PING,
+   PSUBSCRIBE,
+   PUNSUBSCRIBE,
+   SUBSCRIBE,
+   UNSUBSCRIBE,
+   RESET,
+   COMMAND,
+   ECHO,
+   HELLO,
+   AUTH,
+   CONFIG,
+   INFO,
+   READWRITE,
+   READONLY,
+   SELECT,
+   QUIT;
+
+   private final byte[] bytes;
+
+   RespCommand() {
+      this.bytes = name().getBytes(StandardCharsets.US_ASCII);
+   }
+
+   private static final RespCommand[][] indexedRespCommand;
+
+   static {
+      indexedRespCommand = new RespCommand[26][];
+      // Just manual for now, but we may want to dynamically do this with ordinal determining what order within
+      // a sub array the commands are placed
+      indexedRespCommand[0] = new RespCommand[]{AUTH};
+      indexedRespCommand[2] = new RespCommand[]{CONFIG, COMMAND};
+      indexedRespCommand[3] = new RespCommand[]{DECR, DEL};
+      indexedRespCommand[4] = new RespCommand[]{ECHO};
+      indexedRespCommand[6] = new RespCommand[]{GET};
+      indexedRespCommand[7] = new RespCommand[]{HELLO};
+      indexedRespCommand[8] = new RespCommand[]{INCR, INFO};
+      indexedRespCommand[12] = new RespCommand[]{MGET, MSET};
+      indexedRespCommand[15] = new RespCommand[]{PUBLISH, PING, PSUBSCRIBE, PUNSUBSCRIBE};
+      indexedRespCommand[16] = new RespCommand[]{QUIT};
+      indexedRespCommand[17] = new RespCommand[]{RESET, READWRITE, READONLY};
+      indexedRespCommand[18] = new RespCommand[]{SET, SUBSCRIBE, SELECT};
+      indexedRespCommand[20] = new RespCommand[]{UNSUBSCRIBE};
+   }
+
+   public static RespCommand fromByteBuf(ByteBuf buf, int commandLength) {
+      if (buf.readableBytes() < commandLength + 2) {
+         return null;
+      }
+      int readOffset = buf.readerIndex();
+      // We already asserted we have enough bytes, just mark them as read now, since we have to possibly read the
+      // bytes multiple times to check for various commands
+      buf.readerIndex(readOffset + commandLength + 2);
+      byte b = buf.getByte(readOffset);
+      byte ignoreCase = b >= 97 ? (byte) (b - 97) : (byte) (b - 65);
+      if (ignoreCase < 0 || ignoreCase > 25) {
+         return null;
+      }
+      RespCommand[] target = indexedRespCommand[ignoreCase];
+      if (target == null) {
+         return null;
+      }
+      for (RespCommand possible : target) {
+         byte[] possibleBytes = possible.bytes;
+         if (commandLength == possibleBytes.length) {
+            boolean matches = true;
+            // Already checked first byte, so skip that one
+            for (int i = 1; i < possibleBytes.length; ++i) {
+               byte upperByte = possibleBytes[i];
+               byte targetByte = buf.getByte(readOffset + i);
+               if (upperByte == targetByte || upperByte + 22 == targetByte) {
+                  continue;
+               }
+               matches = false;
+               break;
+            }
+            if (matches) {
+               return possible;
+            }
+         }
+      }
+      return null;
+   }
+}


### PR DESCRIPTION
Perf difference on my box

```
Benchmark                                Mode  Cnt  Score    Error  Units
MyBenchmark.testNewNameParsing           avgt    5  0.021 ±  0.001  us/op
MyBenchmark.testSimpleStringNameParsing  avgt    5  0.050 ±  0.001  us/op
MyBenchmark.testStringNameParsing        avgt    5  0.039 ±  0.001  us/op
```

So on average saves about 20 nano seconds or almost half the previous parsing logic. While it doesn't seem like much, the parsing logic overhead for a single command right now is only 750 nano seconds and if you have a pipeline it is much less per command.