### PR TITLE
Rework protostream benchmark a bit to allow for a byte[] argument

### DIFF
--- a/protostream/src/main/java/org/infinispan/protostream/ProtostreamBenchmark.java
+++ b/protostream/src/main/java/org/infinispan/protostream/ProtostreamBenchmark.java
@@ -1,24 +1,16 @@
 package org.infinispan.protostream;
 
-import static org.infinispan.protostream.userclasses.BenchmarkSerializationContextInitializer.INSTANCE;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import org.infinispan.protostream.impl.ByteArrayOutputStreamEx;
+import org.infinispan.protostream.state.AddressState;
+import org.infinispan.protostream.state.ContextState;
+import org.infinispan.protostream.state.MetadataState;
+import org.infinispan.protostream.state.UserState;
 import org.infinispan.protostream.userclasses.Address;
-import org.infinispan.protostream.userclasses.IracEntryVersion;
 import org.infinispan.protostream.userclasses.IracMetadata;
-import org.infinispan.protostream.userclasses.TopologyIracVersion;
 import org.infinispan.protostream.userclasses.User;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -39,82 +31,52 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 public class ProtostreamBenchmark {
 
-   private final SerializationContext ctx;
-   private final Address address;
-   private final User user;
-   private final IracMetadata metadata;
-
-   byte[] addressBytes;
-   byte[] userBytes;
-   byte[] metadataBytes;
-
    @Param({"true", "false"})
    boolean byteArrayOrStream;
 
-   public ProtostreamBenchmark() {
-      ctx = ProtobufUtil.newSerializationContext();
-      INSTANCE.registerSchema(ctx);
-      INSTANCE.registerMarshallers(ctx);
-      address = new Address("That street", "1234-567", 1024, true);
-      Set<Integer> accounts = new HashSet<>();
-      IntStream.range(10, 20).forEach(accounts::add);
-      List<Address> addresses = new ArrayList<>(4);
-      addresses.add(new Address("This street", "1234-678", 256, false));
-      addresses.add(new Address("The other street", "1234-789", 1, true));
-      addresses.add(new Address("Yet another street", "1111-222", 56, true));
-      addresses.add(new Address("Out of street", "3333-111", 1, true));
-      user = new User(10, "John", "Doe", accounts, addresses, 18, User.Gender.MALE, null, Instant.now(), Instant.now().plusMillis(TimeUnit.DAYS.toMillis(30)));
-      Map<String, TopologyIracVersion> versions = new HashMap<>();
-      versions.put("site_1", TopologyIracVersion.newVersion(10));
-      versions.put("site_2", TopologyIracVersion.newVersion(15).increment(15));
-      IracEntryVersion version = new IracEntryVersion(versions);
-      metadata = new IracMetadata("site_1", version);
-
-      try {
-         addressBytes = ProtobufUtil.toWrappedByteArray(ctx, address);
-         userBytes = ProtobufUtil.toWrappedByteArray(ctx, user);
-         metadataBytes = ProtobufUtil.toWrappedByteArray(ctx, metadata);
-      } catch (IOException e) {
-         throw new RuntimeException(e);
-      }
-   }
-
-
    @Benchmark
-   public Object testMarshallAddress() throws IOException {
+   public Object testMarshallAddress(ContextState contextState, AddressState addressState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      Address address = addressState.getAddress();
       if (byteArrayOrStream)
          return ProtobufUtil.toWrappedByteArray(ctx, address);
       else {
-         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(addressBytes.length);
+         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(addressState.getAddressBytes().length);
          ProtobufUtil.toWrappedStream(ctx, os, address);
          return os.getByteBuffer();
       }
    }
 
    @Benchmark
-   public Object testMarshallUser() throws IOException {
+   public Object testMarshallUser(ContextState contextState, UserState userState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      User user = userState.getUser();
       if (byteArrayOrStream)
          return ProtobufUtil.toWrappedByteArray(ctx, user);
       else {
-         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(userBytes.length);
+         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(userState.getUserBytes().length);
          ProtobufUtil.toWrappedStream(ctx, os, user);
          return os.getByteBuffer();
       }
    }
 
    @Benchmark
-   public Object testMarshallIracMetadata() throws IOException {
+   public Object testMarshallIracMetadata(ContextState contextState, MetadataState metadataState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      IracMetadata metadata = metadataState.getMetadata();
       if (byteArrayOrStream)
          return ProtobufUtil.toWrappedByteArray(ctx, metadata);
       else {
-         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(metadataBytes.length);
+         ByteArrayOutputStreamEx os = new ByteArrayOutputStreamEx(metadataState.getMetadataBytes().length);
          ProtobufUtil.toWrappedStream(ctx, os, metadata);
          return os.getByteBuffer();
       }
    }
 
    @Benchmark
-   public Address testUnmarshallAddress() throws IOException {
+   public Address testUnmarshallAddress(ContextState contextState, AddressState addressState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      byte[] addressBytes = addressState.getAddressBytes();
       if (byteArrayOrStream)
          return ProtobufUtil.fromWrappedByteArray(ctx, addressBytes);
       else
@@ -122,7 +84,9 @@ public class ProtostreamBenchmark {
    }
 
    @Benchmark
-   public User testUnmarshallUser() throws IOException {
+   public User testUnmarshallUser(ContextState contextState, UserState userState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      byte[] userBytes = userState.getUserBytes();
       if (byteArrayOrStream)
          return ProtobufUtil.fromWrappedByteArray(ctx, userBytes);
       else
@@ -130,7 +94,9 @@ public class ProtostreamBenchmark {
    }
 
    @Benchmark
-   public IracMetadata testUnmarshallMetadata() throws IOException {
+   public IracMetadata testUnmarshallMetadata(ContextState contextState, MetadataState metadataState) throws IOException {
+      SerializationContext ctx = contextState.getCtx();
+      byte[] metadataBytes = metadataState.getMetadataBytes();
       if (byteArrayOrStream)
          return ProtobufUtil.fromWrappedByteArray(ctx, metadataBytes);
       else

--- a/protostream/src/main/java/org/infinispan/protostream/state/AddressState.java
+++ b/protostream/src/main/java/org/infinispan/protostream/state/AddressState.java
@@ -1,0 +1,44 @@
+package org.infinispan.protostream.state;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.userclasses.Address;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class AddressState {
+   private Address address;
+   private byte[] addressBytes;
+
+   private List<Address> addressesForUser;
+
+   @Setup
+   public void setup(ContextState contextState) throws IOException {
+      address = new Address("That street", "1234-567", 1024, true);
+
+      addressesForUser = new ArrayList<>(4);
+      addressesForUser.add(new Address("This street", "1234-678", 256, false));
+      addressesForUser.add(new Address("The other street", "1234-789", 1, true));
+      addressesForUser.add(new Address("Yet another street", "1111-222", 56, true));
+      addressesForUser.add(new Address("Out of street", "3333-111", 1, true));
+
+      addressBytes = ProtobufUtil.toWrappedByteArray(contextState.getCtx(), address);
+   }
+
+   public Address getAddress() {
+      return address;
+   }
+
+   public byte[] getAddressBytes() {
+      return addressBytes;
+   }
+
+   public List<Address> getAddressesForUser() {
+      return addressesForUser;
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/state/ContextState.java
+++ b/protostream/src/main/java/org/infinispan/protostream/state/ContextState.java
@@ -1,0 +1,25 @@
+package org.infinispan.protostream.state;
+
+import static org.infinispan.protostream.userclasses.BenchmarkSerializationContextInitializer.INSTANCE;
+
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.SerializationContext;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ContextState {
+   private SerializationContext ctx;
+
+   @Setup
+   public void setup() {
+      ctx = ProtobufUtil.newSerializationContext();
+      INSTANCE.registerSchema(ctx);
+      INSTANCE.registerMarshallers(ctx);
+   }
+
+   public SerializationContext getCtx() {
+      return ctx;
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/state/MetadataState.java
+++ b/protostream/src/main/java/org/infinispan/protostream/state/MetadataState.java
@@ -1,0 +1,38 @@
+package org.infinispan.protostream.state;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.userclasses.IracEntryVersion;
+import org.infinispan.protostream.userclasses.IracMetadata;
+import org.infinispan.protostream.userclasses.TopologyIracVersion;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class MetadataState {
+   private IracMetadata metadata;
+
+   byte[] metadataBytes;
+   @Setup
+   public void setup(ContextState contextState) throws IOException {
+      Map<String, TopologyIracVersion> versions = new HashMap<>();
+      versions.put("site_1", TopologyIracVersion.newVersion(10));
+      versions.put("site_2", TopologyIracVersion.newVersion(15).increment(15));
+      IracEntryVersion version = new IracEntryVersion(versions);
+      metadata = new IracMetadata("site_1", version);
+
+      metadataBytes = ProtobufUtil.toWrappedByteArray(contextState.getCtx(), metadata);
+   }
+
+   public IracMetadata getMetadata() {
+      return metadata;
+   }
+
+   public byte[] getMetadataBytes() {
+      return metadataBytes;
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/state/UserState.java
+++ b/protostream/src/main/java/org/infinispan/protostream/state/UserState.java
@@ -1,0 +1,44 @@
+package org.infinispan.protostream.state;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.userclasses.User;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class UserState {
+   @Param({"10", "8096"})
+   int userByteArraySize;
+   private User user;
+   private byte[] userBytes;
+   @Setup
+   public void setup(ContextState contextState, AddressState addressState) throws IOException {
+      byte[] data = new byte[userByteArraySize];
+      Random random = new Random(732183718);
+      random.nextBytes(data);
+      Set<Integer> accounts = new HashSet<>();
+      IntStream.range(10, 20).forEach(accounts::add);
+      user = new User(10, "John", "Doe", accounts, addressState.getAddressesForUser(), 18,
+            User.Gender.MALE, null, Instant.now(), Instant.now().plusMillis(TimeUnit.DAYS.toMillis(30)), data);
+
+      userBytes = ProtobufUtil.toWrappedByteArray(contextState.getCtx(), user);
+   }
+
+   public User getUser() {
+      return user;
+   }
+
+   public byte[] getUserBytes() {
+      return userBytes;
+   }
+}

--- a/protostream/src/main/java/org/infinispan/protostream/userclasses/User.java
+++ b/protostream/src/main/java/org/infinispan/protostream/userclasses/User.java
@@ -2,6 +2,7 @@ package org.infinispan.protostream.userclasses;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -33,8 +34,10 @@ public class User {
    private Instant creationDate;
    private Instant passwordExpirationDate;
 
+   private byte[] encryptedAcountInfo;
+
    @ProtoFactory
-   public User(int id, String name, String surname, Set<Integer> accountIds, List<Address> addresses, Integer age, Gender gender, String notes, Instant creationDate, Instant passwordExpirationDate) {
+   public User(int id, String name, String surname, Set<Integer> accountIds, List<Address> addresses, Integer age, Gender gender, String notes, Instant creationDate, Instant passwordExpirationDate, byte[] encryptedAcountInfo) {
       this.id = id;
       this.name = name;
       this.surname = surname;
@@ -45,6 +48,7 @@ public class User {
       this.notes = notes;
       this.creationDate = creationDate;
       this.passwordExpirationDate = passwordExpirationDate;
+      this.encryptedAcountInfo = encryptedAcountInfo;
    }
 
    @ProtoField(value = 1, required = true)
@@ -137,6 +141,15 @@ public class User {
       this.passwordExpirationDate = passwordExpirationDate;
    }
 
+   @ProtoField(value = 11)
+   public byte[] getEncryptedAcountInfo() {
+      return encryptedAcountInfo;
+   }
+
+   public void setEncryptedAcountInfo(byte[] encryptedAcountInfo) {
+      this.encryptedAcountInfo = encryptedAcountInfo;
+   }
+
    @Override
    public String toString() {
       return "User{" +
@@ -147,9 +160,10 @@ public class User {
             ", addresses=" + addresses +
             ", age=" + age +
             ", gender=" + gender +
-            ", notes=" + notes +
-            ", creationDate='" + creationDate + '\'' +
-            ", passwordExpirationDate='" + passwordExpirationDate + '\'' +
+            ", notes='" + notes + '\'' +
+            ", creationDate=" + creationDate +
+            ", passwordExpirationDate=" + passwordExpirationDate +
+            ", encryptedAcountInfo=" + Arrays.toString(encryptedAcountInfo) +
             '}';
    }
 
@@ -167,11 +181,12 @@ public class User {
             gender == user.gender &&
             Objects.equals(notes, user.notes) &&
             Objects.equals(creationDate, user.creationDate) &&
-            Objects.equals(passwordExpirationDate, user.passwordExpirationDate);
+            Objects.equals(passwordExpirationDate, user.passwordExpirationDate) &&
+            Arrays.equals(encryptedAcountInfo, user.encryptedAcountInfo);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(id, name, surname, accountIds, addresses, age, gender, notes, creationDate, passwordExpirationDate);
+      return Objects.hash(id, name, surname, accountIds, addresses, age, gender, notes, creationDate, passwordExpirationDate, encryptedAcountInfo);
    }
 }


### PR DESCRIPTION
Reworked benchmark to isolate the different types so they can have different parameters and not bloat all the other tests at the same time. Also added a byte[] argument to User to test larger values.