### PR TITLE
Added benchmark for new numeric parser

### DIFF
--- a/resp-decoder/src/main/java/org/infinispan/server/resp/ArgumentParserBenchmark.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/ArgumentParserBenchmark.java
@@ -1,0 +1,93 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(time = 5)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ArgumentParserBenchmark {
+   private static final byte[] ALL_NUMBERS = new byte[] {
+         0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x30
+   };
+
+   private static long toLong(byte[] argument) {
+      if (argument == null || argument.length == 0)
+         throw new NumberFormatException("Empty argument");
+
+      boolean negative = false;
+      int i = 0;
+      if (argument[0] < '0') {
+         if ((argument[0] != '-' && argument[0] != '+') || argument.length == 1)
+            throw new NumberFormatException("Invalid character: " + argument[0]);
+
+         negative = true;
+         i = 1;
+      }
+
+      long result;
+      byte b = argument[i++];
+      if (b < '0' || b > '9')
+         throw new NumberFormatException("Invalid character: " + b);
+      result = (b - 48);
+
+      for (; i < argument.length; i++) {
+         b = argument[i];
+         if (b < '0' || b > '9')
+            throw new NumberFormatException("Invalid character: " + b);
+         result = (result << 3) + (result << 1) + (b - 48);
+      }
+      return negative ? -result : result;
+   }
+
+   @Benchmark
+   public void testOldParse(ArgumentGeneratorState state, Blackhole blackhole) {
+      blackhole.consume(Long.parseLong(new String(state.value, StandardCharsets.US_ASCII)));
+   }
+
+   @Benchmark
+   public void testNewParse(ArgumentGeneratorState state, Blackhole blackhole) {
+      blackhole.consume(toLong(state.value));
+   }
+
+   @State(Scope.Benchmark)
+   public static class ArgumentGeneratorState {
+      @Param({"3", "10", "15"})
+      public int numDigits;
+
+      @Param({"true", "false"})
+      public boolean negative;
+
+      private byte[] value;
+
+      @Setup
+      public void initializeState() {
+         int i;
+         byte[] value;
+         if (negative) {
+            value = new byte[numDigits + 1];
+            value[0] = '-';
+            i = 1;
+         } else {
+            value = new byte[numDigits];
+            i = 0;
+         }
+
+         for (; i < value.length; i++) {
+            value[i] = ALL_NUMBERS[i % ALL_NUMBERS.length];
+         }
+
+         this.value = value;
+      }
+   }
+}

--- a/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/NettyChannelState.java
@@ -27,8 +27,9 @@ public class NettyChannelState {
 
       switch (decoder) {
          case CURRENT:
+            RespDecoder d = new RespDecoder();
             channel.pipeline()
-                  .addLast(new RespDecoder(new OurRespHandler()));
+                  .addLast(d, new RespHandler(d, new OurRespHandler()));
             break;
       }
 


### PR DESCRIPTION
Something I was thinking about during the reviews. I'll open a PR later. Something simple, primarily to avoid allocating the string, based on the `Long.parseLong` but takes advantage of ASCII. But performs nicely, too.

```text
Benchmark                             (negative)  (numDigits)   Mode  Cnt          Score          Error  Units
ArgumentParserBenchmark.testNewParse        true            3  thrpt    5  188612511.104 ± 2126049.568  ops/s
ArgumentParserBenchmark.testNewParse        true           10  thrpt    5   99858290.943 ±  552278.519  ops/s
ArgumentParserBenchmark.testNewParse        true           15  thrpt    5   73876921.040 ±  800576.826  ops/s
ArgumentParserBenchmark.testNewParse       false            3  thrpt    5  216157609.029 ± 3693145.914  ops/s
ArgumentParserBenchmark.testNewParse       false           10  thrpt    5   72188687.619 ± 1027514.847  ops/s
ArgumentParserBenchmark.testNewParse       false           15  thrpt    5   78715259.808 ± 1248356.390  ops/s
ArgumentParserBenchmark.testOldParse        true            3  thrpt    5   51909055.898 ±  716664.051  ops/s
ArgumentParserBenchmark.testOldParse        true           10  thrpt    5   34958172.222 ±  447150.157  ops/s
ArgumentParserBenchmark.testOldParse        true           15  thrpt    5   28424526.271 ±  359053.582  ops/s
ArgumentParserBenchmark.testOldParse       false            3  thrpt    5   51802201.875 ± 1548819.620  ops/s
ArgumentParserBenchmark.testOldParse       false           10  thrpt    5   36253573.844 ±  550445.960  ops/s
ArgumentParserBenchmark.testOldParse       false           15  thrpt    5   28466608.585 ±  607116.406  ops/s
```