### PR TITLE
Check parsing named arguments as an enum

### DIFF
--- a/resp-decoder/src/main/java/org/infinispan/server/resp/EnumParserBenchmark.java
+++ b/resp-decoder/src/main/java/org/infinispan/server/resp/EnumParserBenchmark.java
@@ -1,0 +1,154 @@
+package org.infinispan.server.resp;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(time = 5)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class EnumParserBenchmark {
+
+   private static final ClientEnumOptions[] OPTIONS = ClientEnumOptions.values();
+
+
+   private static <T extends Enum<T>> T parseEnumNew(byte[] bytes, T[] options) {
+      for (T e: options) {
+         String name = e.name();
+         if (name.length() != bytes.length) continue;
+         if (match(bytes, name)) return e;
+      }
+
+      throw new IllegalArgumentException("Not found enum with name " + new String(bytes, StandardCharsets.US_ASCII));
+   }
+
+   private static boolean match(byte[] bytes, String name) {
+      for (int i = 0; i < name.length(); i++) {
+         char c = name.charAt(i);
+         if (c == '-' && bytes[i] != '_' && bytes[i] != '-') return false;
+         if (!Util.caseInsensitiveAsciiCheck(c, bytes[i])) return false;
+      }
+
+      return true;
+   }
+
+   @Benchmark
+   public void testNewParser(ArgumentGeneratorState state, Blackhole blackhole) {
+      for (int i = 0; i < state.numberOfArguments; i++) {
+         ClientEnumOptions e = parseEnumNew(state.arguments[i], OPTIONS);
+         switch (e) {
+            case CACHING:
+            case UNPAUSE:
+            case PAUSE:
+            case NO_EVICT:
+            case GETREDIR:
+            case UNBLOCK:
+            case REPLY:
+            case SETINFO:
+            case SETNAME:
+            case NO_TOUCH:
+            case GETNAME:
+            case ID:
+            case INFO:
+            case LIST:
+            case TRACKING:
+            case TRACKINGINFO:
+               blackhole.consume(e);
+               break;
+            default:
+               throw new IllegalArgumentException("Should not be default");
+         }
+      }
+   }
+
+   @Benchmark
+   public void testOldParsing(ArgumentGeneratorState state,  Blackhole blackhole) {
+      for (int i = 0; i < state.numberOfArguments; i++) {
+         String e = new String(state.arguments[i], StandardCharsets.US_ASCII).toUpperCase();
+         switch (e) {
+            case "CACHING":
+            case "UNPAUSE":
+            case "PAUSE":
+            case "NO_EVICT":
+            case "GETREDIR":
+            case "UNBLOCK":
+            case "REPLY":
+            case "SETINFO":
+            case "SETNAME":
+            case "GETNAME":
+            case "NO_TOUCH":
+            case "ID":
+            case "INFO":
+            case "LIST":
+            case "TRACKING":
+            case "TRACKINGINFO":
+               blackhole.consume(e);
+               break;
+            default:
+               throw new IllegalArgumentException("Should not be default");
+         }
+      }
+   }
+
+   @State(Scope.Benchmark)
+   public static class ArgumentGeneratorState {
+
+      @Param({"1", "5", "10"})
+      public int numberOfArguments;
+
+      private byte[][] arguments;
+
+      @Setup
+      public void initializeState() {
+         List<byte[]> v = new ArrayList<>();
+         int i = 0;
+         for (ClientEnumOptions value : ClientEnumOptions.values()) {
+            if (i++ >= numberOfArguments) {
+               break;
+            }
+            v.add(value.name().getBytes(StandardCharsets.US_ASCII));
+         }
+         arguments = v.toArray(new byte[0][]);
+      }
+   }
+
+   private enum ClientEnumOptions {
+      CACHING,
+      UNPAUSE,
+      PAUSE,
+      NO_EVICT {
+         @Override
+         public String toString() {
+            return "no-evict";
+         }
+      },
+      GETREDIR,
+      UNBLOCK,
+      REPLY,
+      NO_TOUCH {
+         @Override
+         public String toString() {
+            return "no-touch";
+         }
+      },
+      SETINFO,
+      SETNAME,
+      GETNAME,
+      ID,
+      INFO,
+      LIST,
+      TRACKING,
+      TRACKINGINFO,
+   }
+}


### PR DESCRIPTION
This is an experiment to see if it makes sense to integrate. I thought of this for the cases the command has additional named arguments, so instead of going to String and switch case, we go with an enum.

I am unsure, as it adds more complexity, and we have these cases only for some commands. So, let me know what you think. I understand if this is too much and unnecessary.

The numbers:

```text
Benchmark                                               (numberOfArguments)   Mode  Cnt     Score    Error   Units
EnumParserBenchmark.testNewParser                                         1  thrpt    5   116.816 ±  2.587  ops/us
EnumParserBenchmark.testNewParser:·gc.alloc.rate                          1  thrpt    5    ≈ 10⁻⁴           MB/sec
EnumParserBenchmark.testNewParser:·gc.alloc.rate.norm                     1  thrpt    5    ≈ 10⁻⁶             B/op
EnumParserBenchmark.testNewParser:·gc.count                               1  thrpt    5       ≈ 0           counts
EnumParserBenchmark.testNewParser                                         5  thrpt    5    19.420 ±  0.368  ops/us
EnumParserBenchmark.testNewParser:·gc.alloc.rate                          5  thrpt    5    ≈ 10⁻⁴           MB/sec
EnumParserBenchmark.testNewParser:·gc.alloc.rate.norm                     5  thrpt    5    ≈ 10⁻⁶             B/op
EnumParserBenchmark.testNewParser:·gc.count                               5  thrpt    5       ≈ 0           counts
EnumParserBenchmark.testNewParser                                        10  thrpt    5     6.894 ±  0.321  ops/us
EnumParserBenchmark.testNewParser:·gc.alloc.rate                         10  thrpt    5    ≈ 10⁻⁴           MB/sec
EnumParserBenchmark.testNewParser:·gc.alloc.rate.norm                    10  thrpt    5    ≈ 10⁻⁵             B/op
EnumParserBenchmark.testNewParser:·gc.count                              10  thrpt    5       ≈ 0           counts
EnumParserBenchmark.testOldParsing                                        1  thrpt    5    33.423 ±  1.296  ops/us
EnumParserBenchmark.testOldParsing:·gc.alloc.rate                         1  thrpt    5  1529.934 ± 59.330  MB/sec
EnumParserBenchmark.testOldParsing:·gc.alloc.rate.norm                    1  thrpt    5    48.000 ±  0.001    B/op
EnumParserBenchmark.testOldParsing:·gc.count                              1  thrpt    5    99.000           counts
EnumParserBenchmark.testOldParsing:·gc.time                               1  thrpt    5    87.000               ms
EnumParserBenchmark.testOldParsing                                        5  thrpt    5     6.187 ±  0.261  ops/us
EnumParserBenchmark.testOldParsing:·gc.alloc.rate                         5  thrpt    5  1416.107 ± 59.683  MB/sec
EnumParserBenchmark.testOldParsing:·gc.alloc.rate.norm                    5  thrpt    5   240.000 ±  0.001    B/op
EnumParserBenchmark.testOldParsing:·gc.count                              5  thrpt    5   101.000           counts
EnumParserBenchmark.testOldParsing:·gc.time                               5  thrpt    5    96.000               ms
EnumParserBenchmark.testOldParsing                                       10  thrpt    5     2.763 ±  0.216  ops/us
EnumParserBenchmark.testOldParsing:·gc.alloc.rate                        10  thrpt    5  1264.988 ± 99.006  MB/sec
EnumParserBenchmark.testOldParsing:·gc.alloc.rate.norm                   10  thrpt    5   480.000 ±  0.001    B/op
EnumParserBenchmark.testOldParsing:·gc.count                             10  thrpt    5    87.000           counts
EnumParserBenchmark.testOldParsing:·gc.time                              10  thrpt    5    92.000               ms
```

Some notes:

* I include a switch statement because that's the usual way to use the parsed arguments;
* The performance is affected by the way the enum is defined since we iterate over the list;
* To have 0 allocations must save the possible values in the static variable.