### PR TITLE
Update stores benchmark

### DIFF
--- a/cachestores/pom.xml
+++ b/cachestores/pom.xml
@@ -15,15 +15,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.20</jmh.version>
-        <javac.target>1.8</javac.target>
+        <jmh.version>1.37</jmh.version>
+        <javac.target>25</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
         <!--
         <infinispan.version>12.1.0.Dev01</infinispan.version>
         <protostream.version>4.4.0.Alpha4</protostream.version>
         -->
-        <infinispan.version>12.1.0-SNAPSHOT</infinispan.version>
-        <protostream.version>4.4.0.Alpha7</protostream.version>
+        <infinispan.version>16.2.0-SNAPSHOT</infinispan.version>
+        <protostream.version>6.0.4</protostream.version>
     </properties>
 
     <dependencies>
@@ -46,11 +46,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cachestore-rocksdb</artifactId>
-            <version>${infinispan.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-persistence-soft-index</artifactId>
             <version>${infinispan.version}</version>
         </dependency>
   <dependency>
@@ -77,11 +72,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                            <version>${protostream.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/cachestores/src/main/java/org/infinispan/jmhbenchmarks/InfinispanHolder.java
+++ b/cachestores/src/main/java/org/infinispan/jmhbenchmarks/InfinispanHolder.java
@@ -6,25 +6,23 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
-import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.IntSet;
 import org.infinispan.commons.util.IntSets;
+import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.distribution.ch.KeyPartitioner;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.marshall.persistence.PersistenceMarshaller;
 import org.infinispan.marshall.persistence.impl.MarshalledEntryUtil;
 import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.support.SegmentPublisherWrapper;
 import org.infinispan.persistence.support.WaitNonBlockingStore;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -58,6 +56,7 @@ public class InfinispanHolder {
 	@Setup
 	public void initializeState(KeySequenceGenerator generator) throws IOException {
 		ConfigurationBuilder builder = new ConfigurationBuilder();
+		builder.encoding().mediaType(MediaType.APPLICATION_PROTOSTREAM);
 		storeType.apply(builder.persistence())
 				.segmented(segmented)
 				// Make sure runs between don't leak into each other
@@ -66,12 +65,12 @@ public class InfinispanHolder {
 		globalConfigurationBuilder.globalState()
 				.enable()
 				.persistentLocation(Paths.get(System.getProperty("java.io.tmpdir"), getClass().getName()).toString());
-		cacheManager = new DefaultCacheManager(globalConfigurationBuilder.nonClusteredDefault().defaultCacheName("default").build(),
-				builder.build());
-		cache = cacheManager.getCache();
+		cacheManager = new DefaultCacheManager(globalConfigurationBuilder.nonClusteredDefault().build());
+		cacheManager.createCache("default", builder.build());
+		cache = cacheManager.getCache("default");
 
 		marshaller = TestingUtil.extractPersistenceMarshaller(cacheManager);
-		store = TestingUtil.getFirstStore(cache);
+		store = TestingUtil.getFirstStoreWait(cache);
 		int segments = cache.getCacheConfiguration().clustering().hash().numSegments();
 		allSegments = IntSets.immutableRangeSet(segments);
 		halfSegments = IntSets.immutableRangeSet(segments / 2);
@@ -103,6 +102,10 @@ public class InfinispanHolder {
 
 	public WaitNonBlockingStore getStore() {
 		return store;
+	}
+
+	public Cache getCache() {
+		return cache;
 	}
 
 	public int getBatchSize() {

--- a/cachestores/src/main/java/org/infinispan/jmhbenchmarks/JMHBenchmarks.java
+++ b/cachestores/src/main/java/org/infinispan/jmhbenchmarks/JMHBenchmarks.java
@@ -1,17 +1,15 @@
 package org.infinispan.jmhbenchmarks;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Predicate;
 
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.marshall.persistence.impl.MarshalledEntryUtil;
 import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.spi.NonBlockingStore;
 import org.infinispan.persistence.support.SegmentPublisherWrapper;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
-import org.infinispan.util.concurrent.CompletionStages;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -34,6 +32,11 @@ public class JMHBenchmarks {
 	private static MarshallableEntry<?, ?> newEntry(Marshaller marshaller, KeySequenceGenerator generator) {
 		InternalCacheEntry ice = TestInternalCacheEntryFactory.create(generator.getNextKey(), generator.getNextValue());
 		return MarshalledEntryUtil.create(ice, marshaller);
+	}
+
+	@Benchmark
+	public void testCacheWrite(InfinispanHolder holder, KeySequenceGenerator generator) {
+		holder.getCache().put(generator.getNextKey(), generator.getNextValue());
 	}
 
 	@Benchmark

--- a/cachestores/src/main/java/org/infinispan/jmhbenchmarks/StoreType.java
+++ b/cachestores/src/main/java/org/infinispan/jmhbenchmarks/StoreType.java
@@ -5,12 +5,8 @@ import java.io.File;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
-import org.infinispan.configuration.cache.SingleFileStoreConfiguration;
-import org.infinispan.configuration.cache.StoreConfiguration;
-import org.infinispan.persistence.rocksdb.configuration.RocksDBStoreConfiguration;
+import org.infinispan.persistence.file.SingleFileStoreConfigurationBuilder;
 import org.infinispan.persistence.rocksdb.configuration.RocksDBStoreConfigurationBuilder;
-import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfiguration;
-import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationBuilder;
 
 /**
  * @author wburns
@@ -20,7 +16,7 @@ public enum StoreType {
    SINGLE {
       @Override
       AbstractStoreConfigurationBuilder apply(PersistenceConfigurationBuilder builder) {
-         return builder.addSingleFileStore().location(dataRoot + "SFS");
+         return builder.addStore(SingleFileStoreConfigurationBuilder.class).location(dataRoot + "SFS");
       }
 
       @Override
@@ -31,7 +27,7 @@ public enum StoreType {
    SOFT_INDEX {
       @Override
       AbstractStoreConfigurationBuilder apply(PersistenceConfigurationBuilder builder) {
-         return builder.addStore(SoftIndexFileStoreConfigurationBuilder.class)
+         return builder.addSoftIndexFileStore()
                .dataLocation(dataRoot + "SIFS/data")
                .indexLocation(dataRoot + "SIFS/index");
       }


### PR DESCRIPTION
All in all:

* Updating to 16.
* Drop single file store
* Ensure configuration doesn't use tmpfs in tests
* Added a reduced version only for non-concurrent write/read operations.